### PR TITLE
Updated docs for common installer

### DIFF
--- a/content/docs/deployment/_index.md
+++ b/content/docs/deployment/_index.md
@@ -5,7 +5,7 @@ description: Deployment of CSM for Replication
 weight: 2
 ---
 
-The recommended approach for deploying Container Storage Modules (CSM) is by using the CSM Installer.  The CSM installer simplifies the deployment and management of Dell EMC Container Storage Modules and CSI Drivers to provide persistent storage for your containerized workloads.
+The recommended approach for deploying Container Storage Modules (CSM) is by using the CSM Installer.  The CSM Installer simplifies the deployment and management of Dell EMC Container Storage Modules and CSI Drivers to provide persistent storage for your containerized workloads.
 
 The CSM Installer must first be deployed in a Kubernetes environment using Helm.  After which, the CSM Installer can be used through the following interfaces:
 - [CSM CLI](./csmcli)
@@ -17,6 +17,8 @@ Alternatively, the Container Storage Modules and the required CSI Drivers can ea
 - [Dell EMC Container Storage Module for Authorization](../authorization/deployment)
 - [Dell EMC Container Storage Module for Resiliency](../resiliency/deployment)
 - [Dell EMC Container Storage Module for Replication](../replication/deployment)
+
+> __Note__: The CSM Installer supports installing Dell EMC Container Storage Modules and CSI Drivers in environments that do not have any existing deployments of CSM or CSI Drivers. The CSM Installer does not support the upgrade of existing CSM or CSI Driver deployments.
 
 ## How to Deploy the Container Storage Modules Installer
 

--- a/content/docs/deployment/csmcli.md
+++ b/content/docs/deployment/csmcli.md
@@ -125,6 +125,15 @@ You can now add storage endpoints, array type and its unique id
 ./csm add storage --endpoint <storage-array-endpoint> --storage-type <storage-array-type> --unique-id <storage-array-unique-id> --username <storage-array-username>
 ```
 
+The optional `--meta-data` flag can be used to provide additional meta-data for the storage system that is used when creating Secrets for the CSI Driver. These fields include:
+ - isDefault: Set to true if this storage system is used as default for multi-array configuration
+ - skipCertificateValidation: Set to true to skip certificate validation
+ - mdmId: Comma separated list of MDM IPs for PowerFlex
+ - nasName: NAS Name for PowerStore
+ - blockProtocol: Block Protocol for PowerStore
+ - port: Port for PowerScale
+ - portGroups: Comma separated list of port group names for PowerMax
+
 ### Create an Application
 
 You may now create an application depending on the specific use case. Below are the common use cases:


### PR DESCRIPTION
- Adds note about the CSM Installer only supporting environments without existing CSM or CSI drivers.
- Adds details about optional meta-data field when creating storage systems