### PR TITLE
Update cert-manager CRD versions in documentation

### DIFF
--- a/content/docs/observability/deployment/helm.md
+++ b/content/docs/observability/deployment/helm.md
@@ -14,7 +14,7 @@ The Container Storage Modules (CSM) for Observability Helm chart bootstraps an O
 - The cert-manager CustomResourceDefinition resources are created.
 
     ```console
-    $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
+    $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml
     ```
 
 ## Copy the CSI Driver Secret
@@ -136,7 +136,7 @@ dell/karavi-observability       1.0.1           1.0.0           CSM for Observab
 Upgrade to the latest CSM for Observability release:
 
 ```console
-$ helm upgrade --version $latest_chart_version --values values.yaml karavi-observability . -n $namespace
+$ helm upgrade --version $latest_chart_version --values values.yaml karavi-observability dell/karavi-observability -n $namespace
 ```
 
 The [configuration](#configuration) section above lists all the parameters that can be configured using the values.yaml file.

--- a/content/docs/observability/uninstall/_index.md
+++ b/content/docs/observability/uninstall/_index.md
@@ -18,5 +18,5 @@ $ helm delete karavi-observability --namespace [CSM_NAMESPACE]
 You may also want to uninstall the CRDs created for cert-manager.
 
 ```console
-$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.crds.yaml
 ```


### PR DESCRIPTION
This PR updates the new cert-manager CRD version 1.5.3 in all the references. A syntax issue with the helm upgrade for Observability was also fixed.