### PR TITLE
Fix operator install docs

### DIFF
--- a/content/docs/csidriver/installation/operator/_index.md
+++ b/content/docs/csidriver/installation/operator/_index.md
@@ -363,7 +363,7 @@ Note - The `image` field should point to the correct image tag for version of th
 For e.g. - If you wish to install v1.4 of the CSI PowerMax driver, use the image tag `dellemc/csi-powermax:v1.4.0.000R`
 
 ### SideCars
-Although the sidecars field in the driver specification is optional, it is **strongly** recommended to not modify any details related to sidecars provided (if present) in the sample manifests. Any modifications to this should be only done after consulting with Dell EMC support.
+Although the sidecars field in the driver specification is optional, it is **strongly** recommended to not modify any details related to sidecars provided (if present) in the sample manifests. The only exception to this is modifications requested by the documentation, for example, filling in blank IPs or other such system-specific data. Any modifications not specifically requested by the documentation should be only done after consulting with Dell EMC support.
 
 ### Modify the driver specification
 * Choose the correct configVersion. Refer the table containing the full list of supported drivers and versions.

--- a/content/docs/csidriver/installation/operator/powerflex.md
+++ b/content/docs/csidriver/installation/operator/powerflex.md
@@ -39,7 +39,7 @@ Kubernetes Operators make it easy to deploy and manage the entire lifecycle of c
           password: <password in base64>
 ```  
   - Create secret for FTP side by using the command `kubectl create -f sdc-repo-secret.yaml`.
-- Optionally, enable sdc monitor by uncommenting the section for sidecar in manifest yaml.
+- Optionally, enable sdc monitor by uncommenting the section for sidecar in manifest yaml. Please note that you will need to edit the value fields under the HOST_PID and MDM fields by filling the empty quotes with host PID and the MDM IPs. Not filling in these values will cause an error, so please leave this commented out if you don't intend on using it.
 ##### Example CR:  [config/samples/vxflex_v200_ops_47.yaml](https://github.com/dell/dell-csi-operator/blob/master/samples/vxflex_v200_ops_47.yaml)
 ```yaml
         sideCars:
@@ -58,7 +58,6 @@ Kubernetes Operators make it easy to deploy and manage the entire lifecycle of c
           - name: MDM
             value: "10.x.x.x,10.x.x.x"
 ```  
- *Note:* Please comment the sdc-monitor sidecar section if you are not using it. Blank values for MDM will result in error. 
 
 ### Manual SDC Deployment
 


### PR DESCRIPTION
# Description
There is a warning to not mess with sidecar values in the [general operator documentation for all drivers](https://dell.github.io/csm-docs/docs/csidriver/installation/operator/#sidecars), but, in PowerFlex, we need the customer add some values to the yaml file (MDM IPs, etc.), and this is not made clear in the [PowerFlex documentation](general operator documentation for all drivers), causing confusion for users. This is resolved in this PR, with clarifications to both the general operator docs and to the PowerFLex operator docs.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [x] Have you added high-resolution images?

