### PR TITLE
Update powerflex.md

### DIFF
--- a/content/docs/csidriver/release/powerflex.md
+++ b/content/docs/csidriver/release/powerflex.md
@@ -21,4 +21,6 @@ There are no fixed issues in this release.
 
 ### Known Issues
 
-There are no known issues in this release.
+| Issue | Workaround |
+|-------|------------|
+| Delete namespace that has PVCs and pods created with the driver. The External health monitor sidecar crashes as a result of this operation.| Deleting the namespace deletes the PVCs first and then removes the pods in the namespace. This brings a condition where pods exist without their PVCs and causes the external-health-monitor sidecar to crash. This is a known issue and has been reported at https://github.com/kubernetes-csi/external-health-monitor/issues/100|


### PR DESCRIPTION
# Description
- Adding a known issue where the external health monitor crashes if PVCs are not found

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

