### PR TITLE
Added volume health monitor in CSI spec support

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -24,7 +24,7 @@ The CSI Drivers by Dell EMC implement an interface between [CSI](https://kuberne
 | Fedora Core OS|        no        |         5.x       |        no        |         no        |        no        |
 | Red Hat OpenShift | 4.8, 4.8 EUS, 4.9  |   4.8, 4.8 EUS, 4.9 |    4.8, 4.8 EUS, 4.9     |   4.8, 4.8 EUS, 4.9   |  4.8, 4.8 EUS, 4.9 |
 | Mirantis Kubernetes Engine |       3.4.x      |        3.4.x        |       3.4.x     |        3.4.x      |        3.4.x     |
-| Google Anthos |        1.6       |          1.8        |        no        |         no        |        1.7       |
+| Google Anthos |        1.6       |          1.8        |        no        |         1.9        |        1.9       |
 | VMware Tanzu  |        no        |          no      |        NFS     |         NFS    |      NFS      |
 | Rancher Kubernetes Engine |       yes      |          yes         |        yes       |         yes |      yes     |
 {{</table>}}
@@ -46,12 +46,13 @@ The CSI Drivers by Dell EMC implement an interface between [CSI](https://kuberne
 | CSI Ephemeral Volume     | no       | yes | yes   | yes | yes |
 | Topology                 | yes      | yes | yes   | yes | yes |
 | Multi-array              | yes  | yes  | yes | yes | yes     |
+| Volume Health Monitoring | no   | yes  | yes | yes | yes     |
 {{</table>}}
 ### Supported Storage Platforms
 {{<table "table table-striped table-bordered table-sm">}}
 |               | PowerMax         | PowerFlex |&emsp;&emsp; Unity| PowerScale |    PowerStore    |
 |---------------|:----------------:|:-------------------:|:----------------:|:-----------------:|:----------------:|
-| Storage Array |5978.479.479, 5978.669.669, 5978.711.711, Unisphere 9.2|    3.5.x, 3.6.x    | 5.0.5, 5.0.6, 5.0.7, 5.1.0 | OneFS 8.1, 8.2, 9.0, 9.1, 9.2 | 1.0.x, 2.0.x |
+| Storage Array |5978.479.479, 5978.669.669, 5978.711.711, Unisphere 9.2|    3.5.x, 3.6.x    | 5.0.5, 5.0.6, 5.0.7, 5.1.0 | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3 | 1.0.x, 2.0.x |
 {{</table>}}
 ### Backend Storage Details
 {{<table "table table-striped table-bordered table-sm">}}


### PR DESCRIPTION
# Description
Added support for google anthos, volume health monitoring and OneFS 9.3

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/123 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

