### PR TITLE
Remove fedora

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -21,7 +21,6 @@ The CSI Drivers by Dell EMC implement an interface between [CSI](https://kuberne
 | Ubuntu        |       20.04      |       20.04         |       18.04, 20.04      |        18.04, 20.04      |          20.04     |
 | CentOS        |     7.8, 7.9     |      7.8, 7.9       |     7.8, 7.9     |      7.8, 7.9     |     7.8, 7.9     |
 | SLES          |        15SP3        |        15SP3        |       15SP3      |         15SP3     |       15SP3      |
-| Fedora Core OS|        no        |         5.x       |        no        |         no        |        no        |
 | Red Hat OpenShift | 4.8, 4.8 EUS, 4.9  |   4.8, 4.8 EUS, 4.9 |    4.8, 4.8 EUS, 4.9     |   4.8, 4.8 EUS, 4.9   |  4.8, 4.8 EUS, 4.9 |
 | Mirantis Kubernetes Engine |       3.4.x      |        3.4.x        |       3.4.x     |        3.4.x      |        3.4.x     |
 | Google Anthos |        1.6       |          1.8        |        no        |         1.9        |        1.9       |

--- a/content/docs/csidriver/features/powerflex.md
+++ b/content/docs/csidriver/features/powerflex.md
@@ -406,7 +406,7 @@ For configuring Controller HA on the Dell CSI Operator, please refer to the [Del
 
 ## SDC Deployment
 
-The CSI PowerFlex driver version 1.3 and later support the automatic deployment of the PowerFlex SDC on Kubernetes nodes which run the node portion of the CSI driver. The deployment of the SDC kernel module occurs on these nodes with OS platform which support automatic SDC deployment, currently Fedora CoreOS (FCOS) and Red Hat CoreOS (RHCOS). On Kubernetes nodes with OS version not supported by automatic install, you must perform the Manual SDC Deployment steps below. Refer https://hub.docker.com/r/dellemc/sdc for your OS versions.
+The CSI PowerFlex driver version 1.3 and later support the automatic deployment of the PowerFlex SDC on Kubernetes nodes which run the node portion of the CSI driver. The deployment of the SDC kernel module occurs on these nodes with OS platform which support automatic SDC deployment: currently only Red Hat CoreOS (RHCOS). On Kubernetes nodes with OS version not supported by automatic install, you must perform the Manual SDC Deployment steps below. Refer https://hub.docker.com/r/dellemc/sdc for your OS versions.
 
 - On Kubernetes nodes which run the node portion of the CSI driver, the SDC init container runs prior to the driver being installed. It installs the SDC kernel module on the nodes with OS version which supports automatic SDC deployment. If there is an SDC kernel module installed then the version is checked and updated.
 - Optionally, if the SDC monitor is enabled, another container is started and runs as the monitor. Follow PowerFlex SDC documentation to get monitor metrics.

--- a/content/docs/csidriver/features/powerflex.md
+++ b/content/docs/csidriver/features/powerflex.md
@@ -406,7 +406,7 @@ For configuring Controller HA on the Dell CSI Operator, please refer to the [Del
 
 ## SDC Deployment
 
-The CSI PowerFlex driver version 1.3 and later support the automatic deployment of the PowerFlex SDC on Kubernetes nodes which run the node portion of the CSI driver. The deployment of the SDC kernel module occurs on these nodes with OS platform which support automatic SDC deployment: currently only Red Hat CoreOS (RHCOS). On Kubernetes nodes with OS version not supported by automatic install, you must perform the Manual SDC Deployment steps below. Refer https://hub.docker.com/r/dellemc/sdc for your OS versions.
+The CSI PowerFlex driver version 1.3 and later support the automatic deployment of the PowerFlex SDC on Kubernetes nodes which run the node portion of the CSI driver. The deployment of the SDC kernel module occurs on these nodes with OS platforms which support automatic SDC deployment: currently only Red Hat CoreOS (RHCOS). On Kubernetes nodes with OS version not supported by automatic install, you must perform the Manual SDC Deployment steps below. Refer https://hub.docker.com/r/dellemc/sdc for your OS versions.
 
 - On Kubernetes nodes which run the node portion of the CSI driver, the SDC init container runs prior to the driver being installed. It installs the SDC kernel module on the nodes with OS version which supports automatic SDC deployment. If there is an SDC kernel module installed then the version is checked and updated.
 - Optionally, if the SDC monitor is enabled, another container is started and runs as the monitor. Follow PowerFlex SDC documentation to get monitor metrics.

--- a/content/docs/csidriver/installation/helm/powerflex.md
+++ b/content/docs/csidriver/installation/helm/powerflex.md
@@ -46,8 +46,8 @@ Verify that zero padding is enabled on the PowerFlex storage pools that will be 
 ### Install PowerFlex Storage Data Client
 
 The CSI Driver for PowerFlex requires you to have installed the PowerFlex Storage Data Client (SDC) on all Kubernetes nodes which run the node portion of the CSI driver. 
-SDC could be installed automatically by CSI driver install on Kubernetes nodes with OS platform which support automatic SDC deployment, 
-currently Fedora CoreOS (FCOS) and Red Hat CoreOS (RHCOS). 
+SDC could be installed automatically by CSI driver install on Kubernetes nodes with OS platform which support automatic SDC deployment;
+currently only Red Hat CoreOS (RHCOS). 
 On Kubernetes nodes with OS version not supported by automatic install, you must perform the Manual SDC Deployment steps [below](#manual-sdc-deployment).
 Refer to https://hub.docker.com/r/dellemc/sdc for supported OS versions.
 

--- a/content/docs/csidriver/release/powerflex.md
+++ b/content/docs/csidriver/release/powerflex.md
@@ -13,7 +13,8 @@ description: Release notes for PowerFlex CSI driver
 - Added support for CSM Authorization sidecar via Helm.
 - Added v1 extensions to vg snaphot from v1alpha2.
 - Added support to update helm charts to do a helm install without shell scripts.
-- Added support for volume health monitoring.
+- Added support for volume health monitoring
+- Removed support for Fedora CoreOS 
 
 ### Fixed Issues
 


### PR DESCRIPTION
# Description
This PR removes all mention/claim of Fedora CoreOS support for PowerFlex driver. 
This is needed because FCOS was deprioritized for SDC team, resulting in PowerFlex driver 2.1 being unable to install on FCOS clusters

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/131|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

