### PR TITLE
replication hostAliases documented

### DIFF
--- a/content/docs/replication/deployment/configmap-secrets.md
+++ b/content/docs/replication/deployment/configmap-secrets.md
@@ -16,7 +16,7 @@ the respective CSM Replication Controllers.
 
 >Important: Direct network visibility between clusters required for CSM-Replication to work.
 > Cluster-1's API URL has to be pingable from cluster-2 pods and vice versa. If private networks are used and/or DNS is not set up properly - you may need to modify `/etc/hosts` file from within controller's pod.
-> This can be achieved by using helm installation method. Refer to the [link](../insttallation#)
+> This can be achieved by using helm installation method. Refer to the [link](../installation/#using-the-installation-script)
 
 
 >Note: If you are using a single stretched cluster, then you can skip all the following steps

--- a/content/docs/replication/deployment/configmap-secrets.md
+++ b/content/docs/replication/deployment/configmap-secrets.md
@@ -15,7 +15,8 @@ You need to create secrets (using either of the two methods) in each cluster inv
 the respective CSM Replication Controllers.
 
 >Important: Direct network visibility between clusters required for CSM-Replication to work.
-> Cluster-1's API URL has to be pingable from cluster-2 pods and vice versa. 
+> Cluster-1's API URL has to be pingable from cluster-2 pods and vice versa. If private networks are used and/or DNS is not set up properly - you may need to modify `/etc/hosts` file from within controller's pod.
+> This can be achieved by using helm installation method. Refer to the [link](../insttallation#)
 
 
 >Note: If you are using a single stretched cluster, then you can skip all the following steps

--- a/content/docs/replication/deployment/installation.md
+++ b/content/docs/replication/deployment/installation.md
@@ -47,6 +47,12 @@ kubectl create ns dell-replication-controller
 cp ../helm/csm-replication/values.yaml ./myvalues.yaml
 bash scripts/install.sh --values ./myvalues.yaml
 ```
+>Note: Current installation method allows you to specify custom `<FQDN>:<IP>` entry to be appended to controller's `/etc/hosts` file. It can be useful if controller is being deployed in private environment where DNS is not set up properly, but kubernetes clusters use FQDN as API server's address.
+> The feature can be enabled by modifying `values.yaml`.
+>``` hostAliases:
+> enableHostAliases: true
+> hostName: "foo.bar"
+> ip: "10.10.10.10"
 
 This script will do the following:
 1. Install `DellCSIReplicationGroup` CRD in your cluster


### PR DESCRIPTION
# Description
Adds missing parts about hostAlises feature for replication that allows users to inject FQDN:IP entries into their controller's pods

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

