### PR TITLE
Add design limitiation to troubleshooting section

### DIFF
--- a/content/docs/resiliency/troubleshooting.md
+++ b/content/docs/resiliency/troubleshooting.md
@@ -42,3 +42,7 @@ The script collects the following information:
 * For each namespace containing protected pods, the recent events logged in that namespace.
 
 After successful execution of the script, it will deposit a file similar to driver.logs.20210319_1407.tgz in the current directory. Please submit that file with any [issues](https://github.com/dell/csm/issues).
+
+## Actions to take during failure to clean pod resources completely
+
+The node-podmon cleanup algorithm purposefully will not remove the node taint until all the protected volumes have been cleaned up from the node. This works well if the node fault lasts long enough that controller-podmon can evacuate all the protected pods from the node. However, if the failure is short-lived, and controller-podmon does not clean up all the protected pods on the node, or if for some reason node-podmon cannot clean a pod completely, the taint is left on the node, and manual intervention is required. The required intervention is for the operator to reboot the node, which will ensure that no zombie pods survive. Upon seeing the reboot, node-podmon will then remove the taint.


### PR DESCRIPTION
# Description
Adding the resiliency design limitation of zombie resources to the troubleshooting guide as it covers a workaround

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/219|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

