### PR TITLE
Annotation to set the default SC is not beta anymore

### DIFF
--- a/content/docs/csidriver/features/powerflex.md
+++ b/content/docs/csidriver/features/powerflex.md
@@ -290,7 +290,7 @@ metadata:
   annotations:
     meta.helm.sh/release-name: vxflexos
     meta.helm.sh/release-namespace: vxflexos
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   creationTimestamp: "2020-05-27T13:24:55Z"
   labels:
     app.kubernetes.io/managed-by: Helm

--- a/content/docs/csidriver/features/powermax.md
+++ b/content/docs/csidriver/features/powermax.md
@@ -176,7 +176,7 @@ kind: StorageClass
 metadata:
   name: powermax-expand-sc
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: false
+    storageclass.kubernetes.io/is-default-class: false
 provisioner: csi-powermax.dellemc.com
 reclaimPolicy: Delete
 allowVolumeExpansion: true #Set this attribute to true if you plan to expand any PVCs

--- a/content/docs/csidriver/features/powerscale.md
+++ b/content/docs/csidriver/features/powerscale.md
@@ -208,7 +208,7 @@ kind: StorageClass
 metadata:
   name: isilon-expand-sc
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "false"
 provisioner: "csi-isilon.dellemc.com"
 reclaimPolicy: Delete
 parameters:

--- a/content/docs/csidriver/features/powerstore.md
+++ b/content/docs/csidriver/features/powerstore.md
@@ -183,7 +183,7 @@ kind: StorageClass
 metadata:
     name: powerstore-expand-sc
     annotations:
-        storageclass.beta.kubernetes.io/is-default-class: false
+        storageclass.kubernetes.io/is-default-class: false
 provisioner: csi-powerstore.dellemc.com
 reclaimPolicy: Delete
 allowVolumeExpansion: true # Set this attribute to true if you plan to expand any PVCs created using this storage class

--- a/content/docs/csidriver/features/unity.md
+++ b/content/docs/csidriver/features/unity.md
@@ -185,7 +185,7 @@ kind: StorageClass
 metadata:
     name: unity-expand-sc
     annotations:
-        storageclass.beta.kubernetes.io/is-default-class: false
+        storageclass.kubernetes.io/is-default-class: false
 provisioner: csi-unity.dellemc.com
 reclaimPolicy: Delete
 allowVolumeExpansion: true # Set this attribute to true if you plan to expand any PVCs created using this storage class
@@ -542,7 +542,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
     annotations:
-        storageclass.beta.kubernetes.io/is-default-class: "false"
+        storageclass.kubernetes.io/is-default-class: "false"
     name: unity-nfs
 parameters:
     arrayId: "APM0***XXXXXX"


### PR DESCRIPTION
# Description
The annotation to set the default StorageClass syntax is not beta since at least k8s v1.19 : https://v1-19.docs.kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

