### PR TITLE
Adding k8 1.24 support for PowerMax

### DIFF
--- a/content/docs/csidriver/release/powermax.md
+++ b/content/docs/csidriver/release/powermax.md
@@ -13,6 +13,7 @@ description: Release notes for PowerMax CSI driver
 - Added support to configure fsGroupPolicy.
 - Added support to filter topology keys based on user inputs.
 - Added support for SRDF Metro group sharing multiple namespaces.
+- Added support for Kubernetes 1.24.
 
 ### Fixed Issues
 There are no fixed issues in this release.

--- a/content/docs/replication/_index.md
+++ b/content/docs/replication/_index.md
@@ -30,7 +30,7 @@ CSM for Replication provides the following capabilities:
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS | PowerMax | PowerStore | PowerScale |
 |-|-|-|-|
-| Kubernetes    | 1.22, 1.22, 1.24 | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23|
+| Kubernetes    | 1.22, 1.23, 1.24 | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23|
 | Red Hat OpenShift | 4.9, 4.10 | 4.8, 4.9 | 4.8, 4.9 |
 | RHEL          |     7.x, 8.x      |     7.x, 8.x      |  7.x, 8.x |
 | CentOS        |     7.8, 7.9     |     7.8, 7.9     | 7.8, 7.9 |

--- a/content/docs/replication/_index.md
+++ b/content/docs/replication/_index.md
@@ -30,8 +30,8 @@ CSM for Replication provides the following capabilities:
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS | PowerMax | PowerStore | PowerScale |
 |-|-|-|-|
-| Kubernetes    | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23|
-| Red Hat OpenShift | 4.8, 4.9 | 4.8, 4.9 | 4.8, 4.9 |
+| Kubernetes    | 1.22, 1.22, 1.24 | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23|
+| Red Hat OpenShift | 4.9, 4.10 | 4.8, 4.9 | 4.8, 4.9 |
 | RHEL          |     7.x, 8.x      |     7.x, 8.x      |  7.x, 8.x |
 | CentOS        |     7.8, 7.9     |     7.8, 7.9     | 7.8, 7.9 |
 | Ubuntu        |       20.04      |       20.04      | 20.04 |
@@ -96,12 +96,12 @@ The following matrix provides a list of all supported versions for each Dell Sto
 
 | Platforms | PowerMax | PowerStore | PowerScale |
 | -------- | --------- | ---------- | ---------- |
-| Kubernetes | 1.21, 1.22, 1.23  | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23 |
+| Kubernetes | 1.22, 1.23, 1.24  | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23 |
 | CSI Driver | 2.x | 2.x | 2.2+ | 
 
 | Platforms | PowerMax | PowerStore | PowerScale |
 | -------- | --------- | ---------- | ---------- |
-| RedHat Openshift |4.8, 4.9 | 4.8, 4.9 | 4.8, 4.9 |
+| RedHat Openshift |4.9, 4.10 | 4.8, 4.9 | 4.8, 4.9 |
 | CSI Driver | 2.2+ | 2.x | 2.2+ |
 
 For compatibility with storage arrays please refer to corresponding [CSI drivers](../csidriver/#features-and-capabilities)


### PR DESCRIPTION
Added support to Kubernetes 1.24 for Powermax. 


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/298 |

# Checklist:

- [X] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [X] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

