### PR TITLE
Updated Authorization CLI and added missing rolebinding delete

### DIFF
--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -25,6 +25,7 @@ If you feel that something is unclear or missing in this document, please open u
 | [karavictl role delete](#karavictl-role-delete ) | Delete role |
 | [karavictl rolebinding](#karavictl-rolebinding) | Manage role bindings |
 | [karavictl rolebinding create](#karavictl-rolebinding-create) | Create a rolebinding between role and tenant |
+| [karavictl rolebinding delete](#karavictl-rolebinding-delete) | Delete a rolebinding between role and tenant |
 | [karavictl storage](#karavictl-storage) | Manage storage systems |
 | [karavictl storage get](#karavictl-storage-get) | Get details on a registered storage system |
 | [karavictl storage list](#karavictl-storage-list) | List registered storage systems |
@@ -35,7 +36,6 @@ If you feel that something is unclear or missing in this document, please open u
 | [karavictl tenant create](#karavictl-tenant-create) | Create a tenant resource within CSM |
 | [karavictl tenant get](#karavictl-tenant-get) | Get a tenant resource within CSM |
 | [karavictl tenant list](#karavictl-tenant-list) | Lists tenant resources within CSM |
-| [karavictl tenant get](#karavictl-tenant-get) | Get a tenant resource within CSM |
 | [karavictl tenant revoke](#karavictl-tenant-revoke) | Get a tenant resource within CSM |
 | [karavictl tenant delete](#karavictl-tenant-delete) | Deletes a tenant resource within CSM |
 
@@ -539,7 +539,46 @@ karavictl rolebinding create [flags]
 ```
 $ karavictl rolebinding create --role CSISilver --tenant Alice
 ```
-On success, there will be no output. You may run `karavictl tenant get <tenant-name>` to confirm the rolebinding creation occurred.
+On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the rolebinding creation occurred.
+
+
+---
+
+
+
+### karavictl rolebinding delete
+
+Delete a rolebinding between role and tenant
+
+##### Synopsis
+
+Deletes a rolebinding between role and tenant
+
+```
+karavictl rolebinding delete [flags]
+```
+
+##### Options
+
+```
+  -h, --help   help for create
+  -r, --role string     Role name
+  -t, --tenant string   Tenant name
+```
+
+##### Options inherited from parent commands
+
+```
+      --addr string     Address of the server (default "localhost:443")
+      --config string   config file (default is $HOME/.karavictl.yaml)
+```
+
+##### Output
+
+```
+$ karavictl rolebinding delete --role CSISilver --tenant Alice
+```
+On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the rolebinding deletion occurred.
 
 
 
@@ -803,7 +842,7 @@ Manage tenants
 
 ##### Synopsis
 
-Management fortenants
+Management for tenants
 
 ```
 karavictl tenant [flags]
@@ -876,7 +915,7 @@ Get a tenant resource within CSM
 
 ##### Synopsis
 
-Gets a tenant resource within CSM
+Gets a tenant resource and its assigned roles within CSM
 
 ```
 karavictl tenant get [flags]
@@ -903,6 +942,7 @@ $ karavictl tenant get --name Alice
 
 {
   "name": "Alice"
+  "roles": "role-1,role-2"
 }
 
 ```


### PR DESCRIPTION
# Description
- Adds missing `karavictl rolebinding delete` CLI for Authorization
- Removes duplicate `karavictl tenant get` from table
- Fixed samples for `karavictl tenant get` to use the `--name` parameter.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/314  |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

