### PR TITLE
Use sed as alternative to jq

### DIFF
--- a/content/docs/authorization/deployment/helm/_index.md
+++ b/content/docs/authorization/deployment/helm/_index.md
@@ -13,7 +13,7 @@ The following CSM Authorization components are installed in the specified namesp
 - role-service, which configures roles for tenants to be bound to
 - storage-service, which configures backend storage arrays for the proxy-server to foward requests to
 
-The folloiwng third-party components are installed in the specified namespace:
+The following third-party components are installed in the specified namespace:
 - redis, which stores data regarding tenants and their volume ownership, quota, and revokation status
 - redis-commander, a web management tool for Redis
 
@@ -215,10 +215,10 @@ karavictl generate token --tenant Finance --insecure --addr tenant.csm-authoriza
 }
 ```
 
-With [jq](https://stedolan.github.io/jq/), you process the above response to filter the secret manifest. For example:
+Process the above response to filter the secret manifest. For example using sed you can run the following:
 
 ```
-karavictl generate token --tenant Finance --insecure --addr tenant.csm-authorization.com:30016 | jq -r '.Token'
+karavictl generate token --tenant Finance --insecure --addr tenant.csm-authorization.com:30016 | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g'
 apiVersion: v1
 kind: Secret
 metadata:

--- a/content/docs/authorization/deployment/rpm/_index.md
+++ b/content/docs/authorization/deployment/rpm/_index.md
@@ -188,7 +188,7 @@ After creating the role bindings, the next logical step is to generate the acces
 
   ```
   echo === Generating token ===
-  karavictl generate token --tenant $TenantName --insecure --addr "grpc.${AuthorizationProxyHost}" | jq -r '.Token' > token.yaml
+  karavictl generate token --tenant $TenantName --insecure --addr "grpc.${AuthorizationProxyHost}" | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g' > token.yaml
 
   echo === Copy token to Driver Host ===
   sshpass -p ${DriverHostPassword} scp token.yaml ${DriverHostVMUser}@{DriverHostVMIP}:/tmp/token.yaml 
@@ -330,7 +330,7 @@ Replace the data in `config.yaml` under the `data` field with your new, encoded 
 
 >__Note__: If you are updating the signing secret, the tenants need to be updated with new tokens via the `karavictl generate token` command like so. The `--insecure` flag is only necessary if certificates were not provided in `$HOME/.karavi/config.json`
 
-`karavictl generate token --tenant $TenantName --insecure --addr "grpc.${AuthorizationProxyHost}" | jq -r '.Token' > kubectl -n $namespace apply -f -`
+`karavictl generate token --tenant $TenantName --insecure --addr "grpc.${AuthorizationProxyHost}" | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g' | kubectl -n $namespace apply -f -`
 
 ## CSM for Authorization Proxy Server Dynamic Configuration Settings
 


### PR DESCRIPTION
# Description
Add alternative method to extract the token and convert to YAML format. Added note in both Helm and RPM deployment sections. There are more than one way to do this but felt that sed is in all major distributions and not everyone may use Python's json module which is another option I thought about.

## Testing
- Compared output of original command and new alternative. The output is the same except for a newline at the top and bottom with the new approach. Not an issue as YAML is tolerant of blank lines. Did not want to add complexity to the sed command.
- Imported secret into Kubernetes without error.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/390|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [n/a] Have you added high-resolution images?
