### PR TITLE
Update CSM Authorization documentation to include --array-insecure flag

### DIFF
--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -256,6 +256,8 @@ karavictl role get [flags]
 
 ```
   -h, --help   help for get
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -303,6 +305,8 @@ karavictl role list [flags]
 
 ```
   -h, --help   help for list
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -365,6 +369,8 @@ karavictl role create [flags]
 ```
   -f, --from-file string   role data from a file
       --role strings       role in the form <name>=<type>=<id>=<pool>=<quota>
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
   -h, --help               help for create
 ```
 
@@ -411,6 +417,8 @@ karavictl role update [flags]
 ```
   -f, --from-file string   role data from a file
       --role strings       role in the form <name>=<type>=<id>=<pool>=<quota>
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
   -h, --help               help for update
 ```
 
@@ -452,6 +460,8 @@ karavictl role delete <role-name> [flags]
 
 ```
   -h, --help   help for delete
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -523,8 +533,9 @@ karavictl rolebinding create [flags]
 
 ```
   -h, --help   help for create
-  -r, --role string     Role name
-  -t, --tenant string   Tenant name
+  -r, --role string       Role name
+  -t, --tenant string     Tenant name
+      --insecure boolean  insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
@@ -562,8 +573,9 @@ karavictl rolebinding delete [flags]
 
 ```
   -h, --help   help for create
-  -r, --role string     Role name
-  -t, --tenant string   Tenant name
+  -r, --role string      Role name
+  -t, --tenant string    Tenant name
+      --insecure boolean insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
@@ -638,6 +650,8 @@ karavictl storage get [flags]
   -h, --help               help for get
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -680,6 +694,8 @@ karavictl storage list [flags]
 
 ```
   -h, --help   help for list
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -730,12 +746,13 @@ karavictl storage create [flags]
 ```
   -e, --endpoint string    Endpoint of REST API gateway
   -h, --help               help for create
-  -i, --insecure           Insecure skip verify
   -a, --array-insecure     Array insecure skip verify
   -p, --password string    Password (default "****")
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
   -u, --user string        Username (default "admin")
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -773,12 +790,13 @@ karavictl storage update [flags]
 ```
   -e, --endpoint string    Endpoint of REST API gateway
   -h, --help               help for update
-  -i, --insecure           Insecure skip verify
   -a, --array-insecure     Array insecure skip verify
   -p, --pass string        Password (default "****")
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
   -u, --user string        Username (default "admin")
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -818,6 +836,8 @@ karavictl storage delete [flags]
   -h, --help               help for delete
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
@@ -889,6 +909,7 @@ karavictl tenant create [flags]
 ```
   -h, --help   help for create
   -n, --name string   Tenant name
+      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
@@ -928,6 +949,7 @@ karavictl tenant get [flags]
 ```
   -h, --help   help for create
   -n, --name string   Tenant name
+      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
@@ -971,6 +993,7 @@ karavictl tenant list [flags]
 
 ```
   -h, --help   help for create
+      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
@@ -1018,6 +1041,7 @@ karavictl tenant revoke [flags]
 ```
   -h, --help   help for create
   -n, --name string   Tenant name
+      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
@@ -1056,6 +1080,7 @@ karavictl tenant delete [flags]
 ```
   -h, --help   help for create
   -n, --name string   Tenant name
+      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands

--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -731,7 +731,8 @@ karavictl storage create [flags]
   -e, --endpoint string    Endpoint of REST API gateway
   -h, --help               help for create
   -i, --insecure           Insecure skip verify
-  -p, --password string        Password (default "****")
+  -a, --array-insecure     Array insecure skip verify
+  -p, --password string    Password (default "****")
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
   -u, --user string        Username (default "admin")
@@ -746,7 +747,7 @@ karavictl storage create [flags]
 ##### Output
 
 ```
-$ karavictl storage create --endpoint https://1.1.1.1 --insecure --system-id 3000000000011111 --type powerflex --user admin --password ********
+$ karavictl storage create --endpoint https://1.1.1.1 --insecure --array-insecure --system-id 3000000000011111 --type powerflex --user admin --password ********
 ```
 On success, there will be no output. You may run `karavictl storage get --type <storage-system-type> --system-id <storage-system-id>` to confirm the creation occurred.
 
@@ -773,6 +774,7 @@ karavictl storage update [flags]
   -e, --endpoint string    Endpoint of REST API gateway
   -h, --help               help for update
   -i, --insecure           Insecure skip verify
+  -a, --array-insecure     Array insecure skip verify
   -p, --pass string        Password (default "****")
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
@@ -788,7 +790,7 @@ karavictl storage update [flags]
 ##### Output
 
 ```
-$ karavictl storage update --endpoint https://1.1.1.1 --insecure --system-id 3000000000011111 --type powerflex --user admin --password ********
+$ karavictl storage update --endpoint https://1.1.1.1 --insecure --array-insecure --system-id 3000000000011111 --type powerflex --user admin --password ********
 ```
 On success, there will be no output. You may run `karavictl storage get --type <storage-system-type> --system-id <storage-system-id>` to confirm the update occurred.
 

--- a/content/docs/csidriver/installation/helm/isilon.md
+++ b/content/docs/csidriver/installation/helm/isilon.md
@@ -174,7 +174,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
    | sidecarProxyImage | Image for csm-authorization-sidecar. | No | " " |
    | proxyHost | Hostname of the csm-authorization server. | No | Empty |
    | skipCertificateValidation | A boolean that enables/disables certificate validation of the csm-authorization server. | No | true |
-   | **podmon**               | Podmon is an optional feature under development and tech preview. Enable this feature only after contact support for additional information.  |  -        |  -       |
+   | **podmon**               | [Podmon](../../../../resiliency/deployment) is an optional feature to enable application pods to be resilient to node failure.  |  -        |  -       |
    | enabled                  | A boolean that enable/disable podmon feature. |  No      |   false   |
    | image | image for podmon. | No | " " |
 

--- a/content/docs/csidriver/installation/helm/powerflex.md
+++ b/content/docs/csidriver/installation/helm/powerflex.md
@@ -209,7 +209,7 @@ Use the below command to replace or update the secret:
 | enabled | A boolean that enable/disable vg snapshotter feature. | No | false |
 | image | Image for vg snapshotter. | No | " " |
 | **podmon**               | [Podmon](../../../../resiliency/deployment) is an optional feature to enable application pods to be resilient to node failure.  |  -        |  -       |
-| enabled                  | A boolean that enable/disable podmon feature. |  No      |   false   |
+| enabled                  | A boolean that enables/disables podmon feature. |  No      |   false   |
 | image | image for podmon. | No | " " |
 | **authorization** | [Authorization](../../../../authorization/deployment) is an optional feature to apply credential shielding of the backend PowerFlex. | - | - |
 | enabled                  | A boolean that enables/disables authorization feature. |  No      |   false   |

--- a/content/docs/csidriver/installation/helm/powerflex.md
+++ b/content/docs/csidriver/installation/helm/powerflex.md
@@ -208,7 +208,7 @@ Use the below command to replace or update the secret:
 | **vgsnapshotter** | This section allows the configuration of the volume group snapshotter(vgsnapshotter) pod.  | - | - |
 | enabled | A boolean that enable/disable vg snapshotter feature. | No | false |
 | image | Image for vg snapshotter. | No | " " |
-| **podmon**               | Podmon is an optional feature under development and tech preview. Enable this feature only after contact support for additional information.  |  -        |  -       |
+| **podmon**               | [Podmon](../../../../resiliency/deployment) is an optional feature to enable application pods to be resilient to node failure.  |  -        |  -       |
 | enabled                  | A boolean that enable/disable podmon feature. |  No      |   false   |
 | image | image for podmon. | No | " " |
 | **authorization** | [Authorization](../../../../authorization/deployment) is an optional feature to apply credential shielding of the backend PowerFlex. | - | - |

--- a/content/docs/resiliency/deployment.md
+++ b/content/docs/resiliency/deployment.md
@@ -21,7 +21,6 @@ Configure all the helm chart parameters described below before installing the dr
 The drivers that support Helm chart installation allow CSM for Resiliency to be _optionally_ installed by variables in the chart. There is a _podmon_ block specified in the _values.yaml_ file of the chart that will look similar to the text below by default:
 
 ```
-# Podmon is an optional feature under development and tech preview.
 # Enable this feature only after contact support for additional information
 podmon:
   enabled: true


### PR DESCRIPTION
# Description
This PR updates CSM Authorization documentation to include --array-insecure flag when creating or updating storage systems. PR also addresses improvements to add links to Resiliency deployment page from podmon sidecar references in values.yaml for applicable drivers.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/416|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

