### PR TITLE
CSI-Powerstore: Add 1.25 k8s version and 3.2 array support in support matrix 

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -16,7 +16,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 {{<table "table table-striped table-bordered table-sm">}}
 |               | PowerMax         | PowerFlex           | Unity XT         | PowerScale        | PowerStore       |
 |---------------|:----------------:|:-------------------:|:----------------:|:-----------------:|:----------------:|
-| Kubernetes    | 1.23, 1.24, 1.25 | 1.22, 1.23, 1.24    | 1.22, 1.23, 1.24 | 1.22, 1.23, 1.24  | 1.22, 1.23, 1.24 |
+| Kubernetes    | 1.23, 1.24, 1.25 | 1.22, 1.23, 1.24    | 1.22, 1.23, 1.24 | 1.22, 1.23, 1.24  | 1.23, 1.24, 1.25 |
 | RHEL          |     7.x,8.x      |     7.x,8.x         |     7.x,8.x      |     7.x,8.x       |     7.x,8.x      |
 | Ubuntu        |       20.04      |       20.04         |  18.04, 20.04    | 18.04, 20.04      |        20.04     |
 | CentOS        |     7.8, 7.9     |      7.8, 7.9       |     7.8, 7.9     |      7.8, 7.9     |     7.8, 7.9     |
@@ -52,7 +52,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 {{<table "table table-striped table-bordered table-sm">}}
 |               | PowerMax                                                | PowerFlex        | Unity XT                   | PowerScale                         |    PowerStore    |
 |---------------|:-------------------------------------------------------:|:----------------:|:--------------------------:|:----------------------------------:|:----------------:|
-| Storage Array |5978.479.479, 5978.711.711, 6079.xxx.xxx<br>Unisphere 10.0 |    3.5.x, 3.6.x  | 5.0.7, 5.1.0, 5.1.2, 5.2.0 | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3, 9.4 | 1.0.x, 2.0.x, 2.1.x, 3.0     |
+| Storage Array |5978.479.479, 5978.711.711, 6079.xxx.xxx<br>Unisphere 10.0 |    3.5.x, 3.6.x  | 5.0.7, 5.1.0, 5.1.2, 5.2.0 | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3, 9.4 | 1.0.x, 2.0.x, 2.1.x, 3.0, 3.2     |
 {{</table>}}
 ### Backend Storage Details
 {{<table "table table-striped table-bordered table-sm">}}


### PR DESCRIPTION
# Description

- Added 1.25 Kubernetes version.
- Removed 1.22 Kubernetes version.
- Added (3.2) array version.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/478
https://github.com/dell/csm/issues/482 |

# Checklist:

- [X] Have you run a grammar and spell checks against your submission?
- [X] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

Test:
![image](https://user-images.githubusercontent.com/109734493/195030392-e0b9c9fb-7ba9-4384-b564-674e79582935.png)