### PR TITLE
Updated support for Application Mobility and Encryption

### DIFF
--- a/content/docs/applicationmobility/_index.md
+++ b/content/docs/applicationmobility/_index.md
@@ -33,8 +33,8 @@ After a backup has been created, it can be restored on the same Kubernetes clust
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS | Supported Versions |
 |-|-|
-| Kubernetes           |    1.23, 1.24 |
-| Red Hat OpenShift    |    4.10       |
+| Kubernetes           |    1.23, 1.24, 1.25 |
+| Red Hat OpenShift    |    4.10, 4.11       |
 | RHEL                 |     7.x, 8.x  |
 | CentOS               |     7.8, 7.9  |
 {{</table>}}

--- a/content/docs/secure/encryption/_index.md
+++ b/content/docs/secure/encryption/_index.md
@@ -68,7 +68,8 @@ the CSI driver must be restarted to pick up the change.
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS | Supported Versions |
 |-|-|
-| Kubernetes | 1.22, 1.23, 1.24 |
+| Kubernetes | 1.22, 1.23, 1.24, 1.25 |
+| Red Hat OpenShift  | 4.11 |
 | RHEL | 7.9, 8.4 |
 | Ubuntu | 18.04, 20.04 |
 | SLES | 15SP2 |


### PR DESCRIPTION
# Description
Update app mobility secure support for OpenShift 4.11 and Kubernetes 1.25.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#478 |
| dell/csm#480 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

