### PR TITLE
Update healthMonitorInterval to interval in comment

### DIFF
--- a/content/docs/csidriver/installation/helm/isilon.md
+++ b/content/docs/csidriver/installation/helm/isilon.md
@@ -93,7 +93,7 @@ controller:
     #   false: disable checking of health condition of CSI volumes
     # Default value: None
     enabled: false
-    # healthMonitorInterval: Interval of monitoring volume health condition
+    # interval: Interval of monitoring volume health condition
     # Allowed values: Number followed by unit (s,m,h)
     # Examples: 60s, 5m, 1h
     # Default value: 60s


### PR DESCRIPTION
# Description

 Modification in Volume health monitor config parameter.
 The variable mention i.e. `interval` is correct for csi-powerscale, but the comment is not.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|[203](https://github.com/dell/csm/issues/203) |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

