### PR TITLE
added the documentation for dellctl images command.

### DIFF
--- a/content/docs/references/cli/_index.md
+++ b/content/docs/references/cli/_index.md
@@ -789,6 +789,8 @@ Encryption rekey status with name of the rekey object
 
 Prints a Table of the container images Driver needs
 
+**NOTE.**: dellctl images Currently supports csi-vxflexos driver only.
+
 #### Aliases
 
 ```

--- a/content/docs/references/cli/_index.md
+++ b/content/docs/references/cli/_index.md
@@ -789,7 +789,7 @@ Encryption rekey status with name of the rekey object
 
 List the container images needed by csi driver
 
-**NOTE.**: dellctl images Currently supports csi-vxflexos driver only.
+**NOTE.**: dellctl images currently supports csi-vxflexos driver only.
 
 #### Aliases
 

--- a/content/docs/references/cli/_index.md
+++ b/content/docs/references/cli/_index.md
@@ -30,7 +30,7 @@ This document outlines all dellctl commands, their intended use, options that ca
 | [dellctl schedule get](#dellctl-schedule-get) | Get schedules |
 | [dellctl encryption rekey](#dellctl-encryption-rekey) | Rekey an encrypted volume |
 | [dellctl encryption rekey-status](#dellctl-encryption-rekey-status) | Get status of an encryption rekey operation |
-| [dellctl images](#dellctl-images) | Prints a Table of the container images Driver needs |
+| [dellctl images](#dellctl-images) | List the container images needed by csi driver |
 
 
 ## Installation instructions
@@ -787,7 +787,7 @@ Encryption rekey status with name of the rekey object
 
 ### dellctl images
 
-Prints a Table of the container images Driver needs
+List the container images needed by csi driver
 
 **NOTE.**: dellctl images Currently supports csi-vxflexos driver only.
 

--- a/content/docs/references/cli/_index.md
+++ b/content/docs/references/cli/_index.md
@@ -30,6 +30,7 @@ This document outlines all dellctl commands, their intended use, options that ca
 | [dellctl schedule get](#dellctl-schedule-get) | Get schedules |
 | [dellctl encryption rekey](#dellctl-encryption-rekey) | Rekey an encrypted volume |
 | [dellctl encryption rekey-status](#dellctl-encryption-rekey-status) | Get status of an encryption rekey operation |
+| [dellctl images](#dellctl-images) | Prints a Table of the container images Driver needs |
 
 
 ## Installation instructions
@@ -782,3 +783,56 @@ Encryption rekey status with name of the rekey object
 # dellctl encryption rekey-status myrekey
  INFO Status of rekey request myrekey = completed
 ```
+
+
+### dellctl images
+
+Prints a Table of the container images Driver needs
+
+#### Aliases
+
+```
+images,imgs
+```
+
+#### Flags
+
+```
+  Flags:
+  -d, --driver string   csi driver name
+  -h, --help            help for images
+  
+```
+#### Output
+
+
+```
+# dellctl images --driver csi-vxflexos
+Driver Image                    Supported Orchestrator Versions         Sidecar Images
+dellemc/csi-vxflexos:v2.5.0     k8s1.25,k8s1.24,k8s1.23,ocp4.11,ocp4.10 k8s.gcr.io/sig-storage/csi-attacher:v4.0.0
+                                                                        k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0
+                                                                        dellemc/csi-volumegroup-snapshotter:v1.2.0
+                                                                        k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.7.0
+                                                                        k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0
+                                                                        k8s.gcr.io/sig-storage/csi-resizer:v1.6.0
+                                                                        k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.0
+                                                                        dellemc/sdc:3.6.0.6
+
+dellemc/csi-vxflexos:v2.4.0     k8s1.24,k8s1.23,k8s1.22,ocp4.10,ocp4.9  k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+                                                                        k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+                                                                        dellemc/csi-volumegroup-snapshotter:v1.2.0
+                                                                        k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.6.0
+                                                                        k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+                                                                        k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+                                                                        k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+                                                                        dellemc/sdc:3.6.0.6
+
+dellemc/csi-vxflexos:v2.3.0     k8s1.24,k8s1.23,k8s1.22,ocp4.10,ocp4.9  k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
+                                                                        k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
+                                                                        dellemc/csi-volumegroup-snapshotter:v1.0.1
+                                                                        gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.5.0
+                                                                        k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
+                                                                        k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+                                                                        k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1
+                                                                        dellemc/sdc:3.6.0.6
+


### PR DESCRIPTION
# Description
dellctl images is a new cmd which is introduced in the 1.5.1 release. This cmd helps us in listing the Container images needed by csi driver. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/582 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

