### PR TITLE
Feature 408: update CSM authorization documentation to include dellctl

### DIFF
--- a/content/docs/authorization/configuration/powerflex/_index.md
+++ b/content/docs/authorization/configuration/powerflex/_index.md
@@ -59,3 +59,5 @@ Create the karavi-authorization-config secret using this command:
     Enable CSM for Authorization and provide the *proxyHost* address
 
 7. Install the CSI PowerFlex driver
+
+8. (Optional) Install [dellctl](../../../references/cli) to perform Kubernetes administrator commands for additional capabilities (e.g., list volumes). Please refer to the [dellctl documentation page](../../../references/cli) for the installation steps and command list.


### PR DESCRIPTION
# Description
This PR adds a new bullet point in CSM Authorization Poweflex configuration page to include dellctl.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/408|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

