### PR TITLE
Updated Powerstore driver version to 2.5.1 for CSM 1.5.1

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -64,7 +64,7 @@ CSM is made up of multiple components including modules (enterprise capabilities
 
 ## CSM Supported Modules and Dell CSI Drivers
 
-| Modules/Drivers                                                                              | CSM 1.5 | [CSM 1.4](../v1/) | [CSM 1.3.1](../v2/) | [CSM 1.2.1](../v3/) |
+| Modules/Drivers                                                                              | CSM 1.5.1 | [CSM 1.4](../v1/) | [CSM 1.3.1](../v2/) | [CSM 1.2.1](../v3/) |
 | -------------------------------------------------------------------------------------------- | :-----: | :---------------: | :---------------: | :-----------------: |
 | [Authorization](https://hub.docker.com/r/dellemc/csm-authorization-sidecar)                  | v1.5.0  |      v1.4.0       |      v1.3.0       |       v1.2.0        |
 | [Observability](https://hub.docker.com/r/dellemc/csm-topology)                               | v1.4.0  |      v1.3.0       |      v1.2.0       |       v1.1.1        |
@@ -74,7 +74,7 @@ CSM is made up of multiple components including modules (enterprise capabilities
 | [Application Mobility](https://hub.docker.com/r/dellemc/csm-application-mobility-controller) | v0.2.0  |      v0.1.0       |        NA         |         NA          |
 | [CSI Driver for PowerScale](https://hub.docker.com/r/dellemc/csi-isilon/tags)                | v2.5.0  |      v2.4.0       |      v2.3.0       |       v2.2.0        |
 | [CSI Driver for Unity XT](https://hub.docker.com/r/dellemc/csi-unity/tags)                   | v2.5.0  |      v2.4.0       |      v2.3.0       |       v2.2.0        |
-| [CSI Driver for PowerStore](https://hub.docker.com/r/dellemc/csi-powerstore/tags)            | v2.5.0  |      v2.4.0       |      v2.3.0       |       v2.2.0        |
+| [CSI Driver for PowerStore](https://hub.docker.com/r/dellemc/csi-powerstore/tags)            | v2.5.1  |      v2.4.0       |      v2.3.0       |       v2.2.0        |
 | [CSI Driver for PowerFlex](https://hub.docker.com/r/dellemc/csi-vxflexos/tags)               | v2.5.0  |      v2.4.0       |      v2.3.0       |       v2.2.0        |
 | [CSI Driver for PowerMax](https://hub.docker.com/r/dellemc/csi-powermax/tags)                | v2.5.0  |      v2.4.0       |      v2.3.1       |       v2.2.0        |
 


### PR DESCRIPTION
# Description
Updated Powerstore driver version to 2.5.1 for CSM 1.5.1

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/582 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

![image](https://user-images.githubusercontent.com/109620911/220305103-49d2a8ee-0ca5-4dfc-8f05-707fefee19ee.png)
