### PR TITLE
[feature-725]: Remove tenant service ingress

### DIFF
--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -909,7 +909,7 @@ karavictl tenant create [flags]
 ##### Options
 
 ```
-  -a, --approvesdc    To allow/deny SDC approval requests (default true)
+  -a, --approvesdc    To allow/deny SDC approval requests (default true | This flag is only applicable to PowerFlex. This flag will Approve/Deny a tenant's SDC request)
   -h, --help   help for create
   -n, --name string   Tenant name
 ```
@@ -1121,7 +1121,7 @@ karavictl tenant update [flags]
 #### Options
 
 ```
-  -a, --approvesdc    To allow/deny SDC approval requests (default true)
+  -a, --approvesdc    To allow/deny SDC approval requests (default true | This flag is only applicable to PowerFlex. This flag will Approve/Deny a tenant's SDC request)
   -h, --help   help for update
   -n, --name string   Tenant name
 ```

--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -166,16 +166,17 @@ karavictl generate token [flags]
 ##### Options
 
 ```
-      --addr string            host:port address (default "grpc.gatekeeper.cluster:443")
-      --from-config string     File providing self-generated token information
   -h, --help                   help for token
-      --tenant                 Tenant name 
-      --shared-secret string   Shared secret for token signing
+  -t, --tenant string          Tenant name 
+   --access-token-expiration duration    Expiration time of the access token, e.g. 1m30s (default 1m0s)
+   --refresh-token-expiration duration   Expiration time of the refresh token, e.g. 48h (default 720h0m0s)
 ```
 
 ##### Options inherited from parent commands
 
 ```
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
       --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
@@ -536,13 +537,13 @@ karavictl rolebinding create [flags]
   -h, --help   help for create
   -r, --role string       Role name
   -t, --tenant string     Tenant name
-      --insecure boolean  insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
       --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
@@ -573,16 +574,16 @@ karavictl rolebinding delete [flags]
 ##### Options
 
 ```
-  -h, --help   help for create
+  -h, --help   help for delete
   -r, --role string      Role name
   -t, --tenant string    Tenant name
-      --insecure boolean insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
       --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
@@ -908,15 +909,16 @@ karavictl tenant create [flags]
 ##### Options
 
 ```
+  -a, --approvesdc    To allow/deny SDC approval requests (default true)
   -h, --help   help for create
   -n, --name string   Tenant name
-      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
       --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
@@ -948,16 +950,16 @@ karavictl tenant get [flags]
 ##### Options
 
 ```
-  -h, --help   help for create
+  -h, --help   help for get
   -n, --name string   Tenant name
-      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure        Skip certificate validation
 ```
 
 ##### Output
@@ -993,14 +995,14 @@ karavictl tenant list [flags]
 ##### Options
 
 ```
-  -h, --help   help for create
-      --insecure      insecure skip verify flag for Helm deployment
+  -h, --help   help for list
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
       --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
@@ -1040,15 +1042,16 @@ karavictl tenant revoke [flags]
 ##### Options
 
 ```
+  -c, --cancel        Cancel a previous tenant revocation
   -h, --help   help for create
   -n, --name string   Tenant name
-      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
       --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
@@ -1079,16 +1082,16 @@ karavictl tenant delete [flags]
 ##### Options
 
 ```
-  -h, --help   help for create
+  -h, --help   help for delete
   -n, --name string   Tenant name
-      --insecure      insecure skip verify flag for Helm deployment
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure        Skip certificate validation
 ```
 
 ##### Output
@@ -1118,16 +1121,17 @@ karavictl tenant update [flags]
 #### Options
 
 ```
-  -h, --help   help for create
+  -a, --approvesdc    To allow/deny SDC approval requests (default true)
+  -h, --help   help for update
   -n, --name string   Tenant name
-      --approvesdc boolean (Usage: --approvesdc=true/false | This flag is only applicable to PowerFlex. This flag will Approve/Deny a tenant's SDC request )
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --addr string     Address of the server (default "localhost:443")
+      --addr string     Address of the server (default "localhost")
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure        Skip certificate validation
 ```
 
 ##### Output

--- a/content/docs/authorization/configuration/proxy-server/_index.md
+++ b/content/docs/authorization/configuration/proxy-server/_index.md
@@ -14,7 +14,7 @@ The storage administrator must first configure the proxy server with the followi
 - Bind roles to tenants
 
 >__Note__:
-> - The `RPM deployment` will use the address and port of the server (i.e. grpc.<DNS-hostname>:443).
+> - The `RPM deployment` will use the address and of the server.
 > - The `Helm deployment` will use the address and port of the Ingress hosts for the storage, tenant, and role services.
 
 ### Configuring Storage
@@ -42,10 +42,10 @@ A `tenant` is a Kubernetes cluster that a role will be bound to. For example, to
 
 ```yaml
 # RPM Deployment
-karavictl tenant create --name Finance --insecure --addr grpc.<DNS-hostname>:443
+karavictl tenant create --name Finance --insecure --addr DNS-hostname
 
 # Helm Deployment
-karavictl tenant create --name Finance --insecure --addr tenant.csm-authorization.com:<ingress-nginx-controller-port>
+karavictl tenant create --name Finance --insecure --addr csm-authorization.com:<ingress-nginx-controller-port>
 ```
 
 >__Note__: 
@@ -56,10 +56,10 @@ karavictl tenant create --name Finance --insecure --addr tenant.csm-authorizatio
 
 ```yaml
 # RPM Deployment
-karavictl tenant create --name Finance --approvesdc=false --insecure --addr grpc.DNS-hostname:443
+karavictl tenant create --name Finance --approvesdc=false --insecure --addr DNS-hostname
 
 # Helm Deployment
-karavictl tenant create --name Finance --approvesdc=false --insecure --addr tenant.csm-authorization.com:<ingress-nginx-controller-port>
+karavictl tenant create --name Finance --approvesdc=false --insecure --addr csm-authorization.com:<ingress-nginx-controller-port>
 ```
 
 ### Configuring Roles
@@ -83,14 +83,14 @@ A `role binding` binds a role to a tenant. For example, to bind the `FinanceRole
 
 ```yaml
 # RPM Deployment
-karavictl rolebinding create --tenant Finance --role FinanceRole --insecure --addr grpc.<DNS-hostname>:443
+karavictl rolebinding create --tenant Finance --role FinanceRole --insecure --addr DNS-hostname
 
 # Helm Deployment
-karavictl rolebinding create --tenant Finance --role FinanceRole --insecure --addr tenant.csm-authorization.com:<ingress-nginx-controller-port>
+karavictl rolebinding create --tenant Finance --role FinanceRole --insecure --addr csm-authorization.com:<ingress-nginx-controller-port>
 ```
 
 >__Note__: 
-> - The `insecure` flag specifies to skip certificate validation when connecting to the tenant service. Run `karavictl rolebinding create --help` for help.
+> - The `insecure` flag specifies to skip certificate validation when connecting to CSM Authorization. Run `karavictl rolebinding create --help` for help.
 
 ### Generate a Token
 
@@ -106,7 +106,7 @@ After creating the role bindings, the next logical step is to generate the acces
 
   ```
   echo === Generating token ===
-  karavictl generate token --tenant ${tenantName} --insecure --addr grpc.<DNS-hostname>:443 | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g' > token.yaml
+  karavictl generate token --tenant ${tenantName} --insecure --addr DNS-hostname | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g' > token.yaml
 
   echo === Copy token to Driver Host ===
   sshpass -p ${DriverHostPassword} scp token.yaml ${DriverHostVMUser}@{DriverHostVMIP}:/tmp/token.yaml 
@@ -117,7 +117,7 @@ After creating the role bindings, the next logical step is to generate the acces
 Now that the tenant is bound to a role, a JSON Web Token can be generated for the tenant. For example, to generate a token for the `Finance` tenant:
 
 ```
-karavictl generate token --tenant Finance --insecure --addr tenant.csm-authorization.com:<ingress-nginx-controller-port>
+karavictl generate token --tenant Finance --insecure --addr csm-authorization.com:<ingress-nginx-controller-port>
 
 {
   "Token": "\napiVersion: v1\nkind: Secret\nmetadata:\n  name: proxy-authz-tokens\ntype: Opaque\ndata:\n  access: ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SmhkV1FpT2lKcllYSmhkbWtpTENKbGVIQWlPakUyTlRNek1qUXhPRFlzSW1keWIzVndJam9pWm05dklpd2lhWE56SWpvaVkyOXRMbVJsYkd3dWEyRnlZWFpwSWl3aWNtOXNaWE1pT2lKaVlYSWlMQ0p6ZFdJaU9pSnJZWEpoZG1rdGRHVnVZVzUwSW4wLmJIODN1TldmaHoxc1FVaDcweVlfMlF3N1NTVnEyRzRKeGlyVHFMWVlEMkU=\n  refresh: ZXlKaGJHY2lPaUpJVXpJMU5pSXNJblI1Y0NJNklrcFhWQ0o5LmV5SmhkV1FpT2lKcllYSmhkbWtpTENKbGVIQWlPakUyTlRVNU1UWXhNallzSW1keWIzVndJam9pWm05dklpd2lhWE56SWpvaVkyOXRMbVJsYkd3dWEyRnlZWFpwSWl3aWNtOXNaWE1pT2lKaVlYSWlMQ0p6ZFdJaU9pSnJZWEpoZG1rdGRHVnVZVzUwSW4wLkxNbWVUSkZlX2dveXR0V0lUUDc5QWVaTy1kdmN5SHAwNUwyNXAtUm9ZZnM=\n"
@@ -127,7 +127,7 @@ karavictl generate token --tenant Finance --insecure --addr tenant.csm-authoriza
 Process the above response to filter the secret manifest. For example using sed you can run the following:
 
 ```
-karavictl generate token --tenant Finance --insecure --addr tenant.csm-authorization.com:<ingress-nginx-controller-port> | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g'
+karavictl generate token --tenant Finance --insecure --addr csm-authorization.com:<ingress-nginx-controller-port> | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g'
 apiVersion: v1
 kind: Secret
 metadata:

--- a/content/docs/authorization/configuration/proxy-server/_index.md
+++ b/content/docs/authorization/configuration/proxy-server/_index.md
@@ -14,7 +14,7 @@ The storage administrator must first configure the proxy server with the followi
 - Bind roles to tenants
 
 >__Note__:
-> - The `RPM deployment` will use the address and of the server.
+> - The `RPM deployment` will use the address of the server.
 > - The `Helm deployment` will use the address and port of the Ingress hosts for the storage, tenant, and role services.
 
 ### Configuring Storage

--- a/content/docs/authorization/deployment/helm/_index.md
+++ b/content/docs/authorization/deployment/helm/_index.md
@@ -66,16 +66,13 @@ The following third-party components are optionally installed in the specified n
 | authorization.images.storageService | The image to use for the storage-service. | Yes | dellemc/csm-authorization-storage:nightly |
 | authorization.images.opa | The image to use for Open Policy Agent. | Yes | openpolicyagent/opa |
 | authorization.images.opaKubeMgmt | The image to use for Open Policy Agent kube-mgmt. | Yes | openpolicyagent/kube-mgmt:0.11 |
-| authorization.hostname | The hostname to configure the self-signed certificate (if applicable) and the proxy, tenant, role, and storage service Ingresses. | Yes | csm-authorization.com |
+| authorization.hostname | The hostname to configure the self-signed certificate (if applicable) and the proxy, role, and storage service Ingresses. | Yes | csm-authorization.com |
 | authorization.logLevel | CSM Authorization log level. Allowed values: “error”, “warn”/“warning”, “info”, “debug”. | Yes | debug |
 | authorization.zipkin.collectoruri | The URI of the Zipkin instance to export traces. | No | - |
 | authorization.zipkin.probability | The ratio of traces to export. | No | - |
 | authorization.proxyServerIngress.ingressClassName | The ingressClassName of the proxy-service Ingress. | Yes | - |
 | authorization.proxyServerIngress.hosts | Additional host rules to be applied to the proxy-service Ingress.  | No | - |
 | authorization.proxyServerIngress.annotations | Additional annotations for the proxy-service Ingress. | No | - |
-| authorization.tenantServiceIngress.ingressClassName | The ingressClassName of the tenant-service Ingress. | Yes | - |
-| authorization.tenantServiceIngress.hosts | Additional host rules to be applied to the tenant-service Ingress.  | No | - |
-| authorization.tenantServiceIngress.annotations | Additional annotations for the tenant-service Ingress. | No | - |
 | authorization.roleServiceIngress.ingressClassName | The ingressClassName of the role-service Ingress. | Yes | - |
 | authorization.roleServiceIngress.hosts | Additional host rules to be applied to the role-service Ingress.  | No | - |
 | authorization.roleServiceIngress.annotations | Additional annotations for the role-service Ingress. | No | - |
@@ -86,9 +83,6 @@ The following third-party components are optionally installed in the specified n
 | redis.images.redis | The image to use for Redis. | Yes | redis:6.0.8-alpine |
 | redis.images.commander | The image to use for Redis Commander. | Yes | rediscommander/redis-commander:latest |
 | redis.storageClass | The storage class for Redis to use for persistence. If not supplied, the default storage class is used. | No | - |
-
->__Note__: 
-> - The tenant, role, and storage services use GRPC. If the Ingress Controller requires annotations to support GRPC, they must be supplied.
 
 6. Install the driver using `helm`:
 
@@ -135,7 +129,7 @@ Karavictl commands and intended use can be found [here](../../cli/).
 
 The first part of CSM for Authorization deployment is to configure the proxy server. This is controlled by the Storage Administrator.
 
-Configuration is achieved by using `karavictl` to connect to the storage, tenant, and role services. In this example, we will be referencing an installation using `csm-authorization.com` as the authorization.hostname value and the NGINX Ingress Controller accessed via the cluster's master node.
+Configuration is achieved by using `karavictl` to connect to the proxy, storage, and role services. In this example, we will be referencing an installation using `csm-authorization.com` as the authorization.hostname value and the NGINX Ingress Controller accessed via the cluster's master node.
 
 Run `kubectl -n authorization get ingress` and `kubectl -n authorization get service` to see the Ingress rules for these services and the exposed port for accessing these services via the LoadBalancer. For example:
 
@@ -161,10 +155,10 @@ storage-service                                    ClusterIP      00.000.000.000
 tenant-service                                     ClusterIP      00.000.000.000    <none>        000/TCP                    28s
 ```
 
-On the machine running `karavictl`, the `/etc/hosts` file needs to be updated with the Ingress hosts for the storage, tenant, and role services. For example:
+On the machine running `karavictl`, the `/etc/hosts` file needs to be updated with the Ingress hosts for the proxy, storage, and role services. For example:
 
 ```
-<master_node_ip> tenant.csm-authorization.com
+<master_node_ip> csm-authorization.com
 <master_node_ip> role.csm-authorization.com
 <master_node_ip> storage.csm-authorization.com
 ```

--- a/content/docs/authorization/deployment/helm/_index.md
+++ b/content/docs/authorization/deployment/helm/_index.md
@@ -139,7 +139,6 @@ NAME              CLASS   HOSTS                           ADDRESS   PORTS     AG
 proxy-server      nginx   csm-authorization.com                     00, 000   86s
 role-service      nginx   role.csm-authorization.com                00, 000   86s
 storage-service   nginx   storage.csm-authorization.com             00, 000   86s
-tenant-service    nginx   tenant.csm-authorization.com              00, 000   86s
 
 # kubectl -n auth get service
 NAME                                               TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE

--- a/content/docs/authorization/deployment/rpm/_index.md
+++ b/content/docs/authorization/deployment/rpm/_index.md
@@ -72,7 +72,7 @@ A Storage Administrator can execute the shell script, install_karavi_auth.sh as 
         "host": ":8080"
       },
       "zipkin": {
-        "collectoruri": "http://DNS-hostname:9411/api/v2/spans",
+        "collectoruri": "http://zipkin-addr:9411/api/v2/spans",
         "probability": 1
       },
       "certificate": {
@@ -95,21 +95,6 @@ A Storage Administrator can execute the shell script, install_karavi_auth.sh as 
 >__Note__:
 > - `DNS-hostname` refers to the hostname of the system in which the CSM for Authorization server will be installed. This hostname can be found by running `nslookup <IP_address>`
 > - There are a number of ways to create certificates. In a production environment, certificates are usually created and managed by an IT administrator. Otherwise, certificates can be created using OpenSSL.
-
-2. In order to configure secure grpc connectivity, an additional subdomain in the format `grpc.DNS-hostname` is also required. All traffic from `grpc.DNS-hostname` needs to be routed to `DNS-hostname` address, this can be configured by adding a new DNS entry for `grpc.DNS-hostname` or providing a temporary path in the systems `/etc/hosts` file. 
-
->__Note__: The certificate provided in `crtFile` should be valid for both the `DNS-hostname` and the `grpc.DNS-hostname` address. 
-
-    For example, create the certificate config file with alternate names (to include DNS-hostname and grpc.DNS-hostname) and then create the .crt file: 
-
-      ```
-      CN = DNS-hostname
-      subjectAltName = @alt_names
-      [alt_names]
-      DNS.1 = grpc.DNS-hostname.com
-
-      $ openssl x509 -req -in cert_request_file.csr -CA root_CA.pem -CAkey private_key_File.key -CAcreateserial -out DNS-hostname.com.crt -days 365 -sha256
-      ```
 
 3. To install the rpm package on the system, you must first extract the contents of the tar file with the command:
 
@@ -178,7 +163,7 @@ Replace the data in `config.yaml` under the `data` field with your new, encoded 
 
 >__Note__: If you are updating the signing secret, the tenants need to be updated with new tokens via the `karavictl generate token` command like so. The `--insecure` flag is required if certificates were not provided in `$HOME/.karavi/config.json`
 
-`karavictl generate token --tenant $TenantName --insecure --addr grpc.DNS-hostname:443 | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g' | kubectl -n $namespace apply -f -`
+`karavictl generate token --tenant $TenantName --insecure --addr DNS-hostname | sed -e 's/"Token": //' -e 's/[{}"]//g' -e 's/\\n/\n/g' | kubectl -n $namespace apply -f -`
 
 ## CSM for Authorization Proxy Server Dynamic Configuration Settings
 

--- a/content/docs/authorization/troubleshooting.md
+++ b/content/docs/authorization/troubleshooting.md
@@ -52,20 +52,6 @@ For OPA related logs, run:
 $ k3s kubectl logs deploy/proxy-server -n karavi -c opa
 ```
 
-### Running "karavictl tenant" commands result in an HTTP 504 error
-This situation may occur if there are Iptables or other firewall rules preventing communication with the provided `<grpc-address>`:
-```
-$ karavictl tenant list --addr <grpc-address>
-{
-  "ErrorMsg": "rpc error: code = Unavailable desc = Gateway Timeout: HTTP status code 504; 
-  transport: received the unexpected content-type \"text/plain; charset=utf-8\""
-}
-```
-__Resolution__
-
-Consult with your system administrator or Iptables/firewall documentation. If there are rules in place to 
-prevent communication with the `<grpc-address>`, either new rules must be created or existing rules must be updated.
-
 ### Installation fails to install policies
 If SELinux is enabled, the policies may fail to install:
 

--- a/content/docs/authorization/troubleshooting.md
+++ b/content/docs/authorization/troubleshooting.md
@@ -52,6 +52,20 @@ For OPA related logs, run:
 $ k3s kubectl logs deploy/proxy-server -n karavi -c opa
 ```
 
+### Running "karavictl tenant" commands result in an HTTP 504 error
+This situation may occur if there are Iptables or other firewall rules preventing communication with the provided `DNS-hostname`:
+```
+$ karavictl tenant list --addr <DNS-hostname>
+{
+  "ErrorMsg": "rpc error: code = Unavailable desc = Gateway Timeout: HTTP status code 504; 
+  transport: received the unexpected content-type \"text/plain; charset=utf-8\""
+}
+```
+__Resolution__
+
+Consult with your system administrator or Iptables/firewall documentation. If there are rules in place to 
+prevent communication with the `DNS-hostname`, either new rules must be created or existing rules must be updated.
+
 ### Installation fails to install policies
 If SELinux is enabled, the policies may fail to install:
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -142,7 +142,6 @@ To deploy the Operator, follow the instructions available [here](../../#installa
    | PROXY_HOST | The hostname to configure the self-signed certificate (if applicable), and the proxy, tenant, role, and storage service Ingresses. | Yes | csm-authorization.com |
    | PROXY_INGRESS_CLASSNAME | The ingressClassName of the proxy-service Ingress. | Yes | nginx |
    | PROXY_INGRESS_HOSTS | Additional host rules to be applied to the proxy-service Ingress.  | No | authorization-ingress-nginx-controller.authorization.svc.cluster.local |
-   | TENANT_INGRESS_CLASSNAME | The ingressClassName of the tenant-service Ingress. | Yes | nginx |
    | ROLE_INGRESS_CLASSNAME | The ingressClassName of the role-service Ingress. | Yes | nginx |
    | STORAGE_INGRESS_CLASSNAME | The ingressClassName of the storage-service Ingress. | Yes | nginx |
    | REDIS_STORAGE_CLASS | The storage class for Redis to use for persistence. If not supplied, the default storage class is used. | Yes | - |

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -153,9 +153,9 @@ To deploy the Operator, follow the instructions available [here](../../#installa
 **Optional:**
 To enable reporting of trace data with [Zipkin](https://zipkin.io/), use the `csm-config-params` configMap in the sample CR or dynamically by editing the configMap.
 
-  Add the Zipkin values to the configMap:
+  Add the Zipkin values to the configMap where `ZIPKIN_ADDRESS` is the IP address or hostname of the Zipkin server.
   ```
-  ZIPKIN_URI: "http://zipkin-addr:9411/api/v2/spans"
+  ZIPKIN_URI: "http://ZIPKIN-ADDRESS:9411/api/v2/spans"
   ZIPKIN_PROBABILITY: "1.0"
   ```
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -155,7 +155,7 @@ To enable reporting of trace data with [Zipkin](https://zipkin.io/), use the `cs
 
   Add the Zipkin values to the configMap where `ZIPKIN_ADDRESS` is the IP address or hostname of the Zipkin server.
   ```
-  ZIPKIN_URI: "http://ZIPKIN-ADDRESS:9411/api/v2/spans"
+  ZIPKIN_URI: "http://ZIPKIN_ADDRESS:9411/api/v2/spans"
   ZIPKIN_PROBABILITY: "1.0"
   ```
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -31,11 +31,11 @@ To deploy the Operator, follow the instructions available [here](../../#installa
 
     After editing the file, run this command to create a secret called `karavi-config-secret`:
     
-    `kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/csm-authorization/config.yaml`
+    `kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/authorization/config.yaml`
 
     Use this command to replace or update the secret:
 
-    `kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/csm-authorization/config.yaml -o yaml --dry-run=client | kubectl replace -f -`
+    `kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/authorization/config.yaml -o yaml --dry-run=client | kubectl replace -f -`
 
 4. Create the `karavi-storage-secret` using the file provided [here](https://github.com/dell/csm-operator/blob/main/samples/authorization/karavi-storage-secret.yaml) to store storage system credentials.
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -155,7 +155,7 @@ To enable reporting of trace data with [Zipkin](https://zipkin.io/), use the `cs
 
   Add the Zipkin values to the configMap:
   ```
-  ZIPKIN_URI: "http://PROXY_HOST:9411/api/v2/spans"
+  ZIPKIN_URI: "http://zipkin-addr:9411/api/v2/spans"
   ZIPKIN_PROBABILITY: "1.0"
   ```
 


### PR DESCRIPTION
# Description

Updates to remove the tenant-service endpoint and for `karavictl` tenant commands to send requests to the proxy-server.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/725|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

