### PR TITLE
Removing ingress for role-service

### DIFF
--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -260,14 +260,14 @@ karavictl role get [flags]
 
 ```
   -h, --help   help for get
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
 
 ```
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Output
@@ -309,14 +309,14 @@ karavictl role list [flags]
 
 ```
   -h, --help   help for list
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
 
 ```
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Output
@@ -373,8 +373,6 @@ karavictl role create [flags]
 ```
   -f, --from-file string   role data from a file
       --role strings       role in the form <name>=<type>=<id>=<pool>=<quota>
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
   -h, --help               help for create
 ```
 
@@ -385,6 +383,8 @@ karavictl role create [flags]
 
 ```
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Output
@@ -421,8 +421,6 @@ karavictl role update [flags]
 ```
   -f, --from-file string   role data from a file
       --role strings       role in the form <name>=<type>=<id>=<pool>=<quota>
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
   -h, --help               help for update
 ```
 
@@ -430,6 +428,8 @@ karavictl role update [flags]
 
 ```
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Output
@@ -464,14 +464,14 @@ karavictl role delete <role-name> [flags]
 
 ```
   -h, --help   help for delete
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Options inherited from parent commands
 
 ```
       --config string   config file (default is $HOME/.karavictl.yaml)
+      --insecure           insecure skip verify flag for Helm deployment
+      --addr               address of the container for Helm deployment (pod:port)
 ```
 
 ##### Output

--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -225,13 +225,13 @@ karavictl role [flags]
 ##### Options
 
 ```
-  -h, --help   help for role
+  -h, --help   Help for role
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.karavictl.yaml)
+      --config string   Config file (default is $HOME/.karavictl.yaml)
 ```
 
 ##### Output
@@ -265,9 +265,9 @@ karavictl role get [flags]
 ##### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.karavictl.yaml)
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
+      --config string   Config file (default is $HOME/.karavictl.yaml)
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
 ```
 
 ##### Output
@@ -308,15 +308,15 @@ karavictl role list [flags]
 ##### Options
 
 ```
-  -h, --help   help for list
+  -h, --help   Help for list
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.karavictl.yaml)
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
+      --config string   Config file (default is $HOME/.karavictl.yaml)
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
 ```
 
 ##### Output
@@ -371,9 +371,9 @@ karavictl role create [flags]
 ##### Options
 
 ```
-  -f, --from-file string   role data from a file
-      --role strings       role in the form <name>=<type>=<id>=<pool>=<quota>
-  -h, --help               help for create
+  -f, --from-file string   Role data from a file
+      --role strings       Role in the form <name>=<type>=<id>=<pool>=<quota>
+  -h, --help               Help for create
 ```
 
 *NOTE:* 
@@ -382,9 +382,9 @@ karavictl role create [flags]
 ##### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.karavictl.yaml)
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
+      --config string   Config file (default is $HOME/.karavictl.yaml)
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
 ```
 
 ##### Output
@@ -419,17 +419,17 @@ karavictl role update [flags]
 ##### Options
 
 ```
-  -f, --from-file string   role data from a file
-      --role strings       role in the form <name>=<type>=<id>=<pool>=<quota>
-  -h, --help               help for update
+  -f, --from-file string   Role data from a file
+      --role strings       Role in the form <name>=<type>=<id>=<pool>=<quota>
+  -h, --help               Help for update
 ```
 
 ##### Options inherited from parent commands
 
 ```
       --config string   config file (default is $HOME/.karavictl.yaml)
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
 ```
 
 ##### Output
@@ -463,15 +463,15 @@ karavictl role delete <role-name> [flags]
 ##### Options
 
 ```
-  -h, --help   help for delete
+  -h, --help   Help for delete
 ```
 
 ##### Options inherited from parent commands
 
 ```
-      --config string   config file (default is $HOME/.karavictl.yaml)
-      --insecure           insecure skip verify flag for Helm deployment
-      --addr               address of the container for Helm deployment (pod:port)
+      --config string   Config file (default is $HOME/.karavictl.yaml)
+      --addr string     Address of the server (default "localhost")
+      --insecure        Skip certificate validation
 ```
 
 ##### Output

--- a/content/docs/authorization/configuration/proxy-server/_index.md
+++ b/content/docs/authorization/configuration/proxy-server/_index.md
@@ -15,7 +15,7 @@ The storage administrator must first configure the proxy server with the followi
 
 >__Note__:
 > - The `RPM deployment` will use the address of the server.
-> - The `Helm deployment` will use the address and port of the Ingress hosts for the proxy-server and role services.
+> - The `Helm deployment` will use the address and port of the Ingress hosts for the proxy-server.
 
 ### Configuring Storage
 
@@ -71,7 +71,7 @@ A `role` consists of a name, the storage to use, and the quota limit for the sto
 karavictl role create --role=FinanceRole=powerflex=${systemID}=myStoragePool=100GB
 
 # Helm Deployment
-karavictl role create --insecure --addr role.csm-authorization.com:30016 --role=FinanceRole=powerflex=${systemID}=myStoragePool=100GB
+karavictl role create --insecure --addr csm-authorization.com:30016 --role=FinanceRole=powerflex=${systemID}=myStoragePool=100GB
 ```
 
 >__Note__: 

--- a/content/docs/authorization/deployment/helm/_index.md
+++ b/content/docs/authorization/deployment/helm/_index.md
@@ -66,7 +66,7 @@ The following third-party components are optionally installed in the specified n
 | authorization.images.storageService | The image to use for the storage-service. | Yes | dellemc/csm-authorization-storage:nightly |
 | authorization.images.opa | The image to use for Open Policy Agent. | Yes | openpolicyagent/opa |
 | authorization.images.opaKubeMgmt | The image to use for Open Policy Agent kube-mgmt. | Yes | openpolicyagent/kube-mgmt:0.11 |
-| authorization.hostname | The hostname to configure the self-signed certificate (if applicable) and the proxy and role Ingresses. | Yes | csm-authorization.com |
+| authorization.hostname | The hostname to configure the self-signed certificate (if applicable) and the proxy Ingresses. | Yes | csm-authorization.com |
 | authorization.logLevel | CSM Authorization log level. Allowed values: “error”, “warn”/“warning”, “info”, “debug”. | Yes | debug |
 | authorization.zipkin.collectoruri | The URI of the Zipkin instance to export traces. | No | - |
 | authorization.zipkin.probability | The ratio of traces to export. | No | - |
@@ -126,7 +126,7 @@ Karavictl commands and intended use can be found [here](../../cli/).
 
 The first part of CSM for Authorization deployment is to configure the proxy server. This is controlled by the Storage Administrator.
 
-Configuration is achieved by using `karavictl` to connect to the proxy and role services. In this example, we will be referencing an installation using `csm-authorization.com` as the authorization.hostname value and the NGINX Ingress Controller accessed via the cluster's master node.
+Configuration is achieved by using `karavictl` to connect to the proxy service. In this example, we will be referencing an installation using `csm-authorization.com` as the authorization.hostname value and the NGINX Ingress Controller accessed via the cluster's master node.
 
 Run `kubectl -n authorization get ingress` and `kubectl -n authorization get service` to see the Ingress rules for these services and the exposed port for accessing these services via the LoadBalancer. For example:
 
@@ -134,7 +134,6 @@ Run `kubectl -n authorization get ingress` and `kubectl -n authorization get ser
 # kubectl -n authorization get ingress
 NAME              CLASS   HOSTS                           ADDRESS   PORTS     AGE
 proxy-server      nginx   csm-authorization.com                     00, 000   86s
-role-service      nginx   role.csm-authorization.com                00, 000   86s
 
 # kubectl -n auth get service
 NAME                                               TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
@@ -154,7 +153,6 @@ On the machine running `karavictl`, the `/etc/hosts` file needs to be updated wi
 
 ```
 <master_node_ip> csm-authorization.com
-<master_node_ip> role.csm-authorization.com
 ```
 
 The port that exposes these services is `30016`.

--- a/content/docs/authorization/deployment/helm/_index.md
+++ b/content/docs/authorization/deployment/helm/_index.md
@@ -66,7 +66,7 @@ The following third-party components are optionally installed in the specified n
 | authorization.images.storageService | The image to use for the storage-service. | Yes | dellemc/csm-authorization-storage:nightly |
 | authorization.images.opa | The image to use for Open Policy Agent. | Yes | openpolicyagent/opa |
 | authorization.images.opaKubeMgmt | The image to use for Open Policy Agent kube-mgmt. | Yes | openpolicyagent/kube-mgmt:0.11 |
-| authorization.hostname | The hostname to configure the self-signed certificate (if applicable) and the proxy Ingresses. | Yes | csm-authorization.com |
+| authorization.hostname | The hostname to configure the self-signed certificate (if applicable) and the proxy Ingress. | Yes | csm-authorization.com |
 | authorization.logLevel | CSM Authorization log level. Allowed values: “error”, “warn”/“warning”, “info”, “debug”. | Yes | debug |
 | authorization.zipkin.collectoruri | The URI of the Zipkin instance to export traces. | No | - |
 | authorization.zipkin.probability | The ratio of traces to export. | No | - |

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -139,10 +139,9 @@ To deploy the Operator, follow the instructions available [here](../../#installa
    | Parameter | Description | Required | Default |
    | --------- | ----------- | -------- |-------- |
    | **authorization** | This section configures the CSM-Authorization components. | - | - |
-   | PROXY_HOST | The hostname to configure the self-signed certificate (if applicable), and the proxy, tenant, role, and storage service Ingresses. | Yes | csm-authorization.com |
+   | PROXY_HOST | The hostname to configure the self-signed certificate (if applicable), and the proxy service Ingresses. | Yes | csm-authorization.com |
    | PROXY_INGRESS_CLASSNAME | The ingressClassName of the proxy-service Ingress. | Yes | nginx |
    | PROXY_INGRESS_HOSTS | Additional host rules to be applied to the proxy-service Ingress.  | No | authorization-ingress-nginx-controller.authorization.svc.cluster.local |
-   | ROLE_INGRESS_CLASSNAME | The ingressClassName of the role-service Ingress. | Yes | nginx |
    | REDIS_STORAGE_CLASS | The storage class for Redis to use for persistence. If not supplied, the default storage class is used. | Yes | - |
    | **ingress-nginx** | This section configures the enablement of the NGINX Ingress Controller. | - | - |
    | enabled | Enable/Disable deployment of the NGINX Ingress Controller. Set to false if you already have an Ingress Controller installed. | No | true |

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -139,7 +139,7 @@ To deploy the Operator, follow the instructions available [here](../../#installa
    | Parameter | Description | Required | Default |
    | --------- | ----------- | -------- |-------- |
    | **authorization** | This section configures the CSM-Authorization components. | - | - |
-   | PROXY_HOST | The hostname to configure the self-signed certificate (if applicable), and the proxy service Ingresses. | Yes | csm-authorization.com |
+   | PROXY_HOST | The hostname to configure the self-signed certificate (if applicable), and the proxy service Ingress. | Yes | csm-authorization.com |
    | PROXY_INGRESS_CLASSNAME | The ingressClassName of the proxy-service Ingress. | Yes | nginx |
    | PROXY_INGRESS_HOSTS | Additional host rules to be applied to the proxy-service Ingress.  | No | authorization-ingress-nginx-controller.authorization.svc.cluster.local |
    | REDIS_STORAGE_CLASS | The storage class for Redis to use for persistence. If not supplied, the default storage class is used. | Yes | - |


### PR DESCRIPTION
# Description
Updated documentation on the Karavictl, and Authorization pages to cover the changes made by this PR: (https://github.com/dell/karavi-authorization/pull/226) which covers role-service being removed from the Ingress.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/725|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

