### PR TITLE
Added changes for 1.6.1 release

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -64,23 +64,23 @@ CSM is made up of multiple components including modules (enterprise capabilities
 
 ## CSM Supported Modules and Dell CSI Drivers
 
-| Modules/Drivers                                                                              | CSM 1.6 | [CSM 1.5.1](../v1/) | [CSM 1.4](../v2/) | [CSM 1.3.1](../v3/) |
-| -------------------------------------------------------------------------------------------- | :-----: | :---------------: | :---------------: | :-----------------: |
-| [Authorization](https://hub.docker.com/r/dellemc/csm-authorization-sidecar)                  | v1.6.0  |      v1.5.1       |      v1.4.0       |       v1.3.0        |
-| [Observability](https://hub.docker.com/r/dellemc/csm-topology)                               | v1.5.0  |      v1.4.0       |      v1.3.0       |       v1.2.0        |
-| [Replication](https://hub.docker.com/r/dellemc/dell-replication-controller)                  | v1.4.0  |      v1.3.1       |      v1.3.0       |       v1.3.0        |
-| [Resiliency](https://hub.docker.com/r/dellemc/podmon)                                        | v1.5.0  |      v1.4.0       |      v1.3.0       |       v1.2.0        |
-| [Encryption](https://hub.docker.com/r/dellemc/csm-encryption)                                | v0.3.0  |      v0.2.0       |      v0.1.0       |         NA          |
-| [Application Mobility](https://hub.docker.com/r/dellemc/csm-application-mobility-controller) | v0.3.0  |      v0.2.0       |      v0.1.0       |         NA          |
-| [CSI Driver for PowerScale](https://hub.docker.com/r/dellemc/csi-isilon/tags)                | v2.6.0  |      v2.5.0       |      v2.4.0       |       v2.3.0        |
-| [CSI Driver for Unity XT](https://hub.docker.com/r/dellemc/csi-unity/tags)                   | v2.6.0  |      v2.5.0       |      v2.4.0       |       v2.3.0        |
-| [CSI Driver for PowerStore](https://hub.docker.com/r/dellemc/csi-powerstore/tags)            | v2.6.0  |      v2.5.1       |      v2.4.0       |       v2.3.0        |
-| [CSI Driver for PowerFlex](https://hub.docker.com/r/dellemc/csi-vxflexos/tags)               | v2.6.0  |      v2.5.0       |      v2.4.0       |       v2.3.0        |
-| [CSI Driver for PowerMax](https://hub.docker.com/r/dellemc/csi-powermax/tags)                | v2.6.0  |      v2.5.0       |      v2.4.0       |       v2.3.1        |
+| Modules/Drivers                                                                              | CSM 1.6.1 | [CSM 1.5.1](../v1/) | [CSM 1.4](../v2/) | [CSM 1.3.1](../v3/) |
+| -------------------------------------------------------------------------------------------- | :-------: | :---------------: | :---------------: | :-----------------: |
+| [Authorization](https://hub.docker.com/r/dellemc/csm-authorization-sidecar)                  |  v1.6.0   |      v1.5.1       |      v1.4.0       |       v1.3.0        |
+| [Observability](https://hub.docker.com/r/dellemc/csm-topology)                               |  v1.5.0   |      v1.4.0       |      v1.3.0       |       v1.2.0        |
+| [Replication](https://hub.docker.com/r/dellemc/dell-replication-controller)                  |  v1.4.0   |      v1.3.1       |      v1.3.0       |       v1.3.0        |
+| [Resiliency](https://hub.docker.com/r/dellemc/podmon)                                        |  v1.5.0   |      v1.4.0       |      v1.3.0       |       v1.2.0        |
+| [Encryption](https://hub.docker.com/r/dellemc/csm-encryption)                                |  v0.3.0   |      v0.2.0       |      v0.1.0       |         NA          |
+| [Application Mobility](https://hub.docker.com/r/dellemc/csm-application-mobility-controller) |  v0.3.0   |      v0.2.0       |      v0.1.0       |         NA          |
+| [CSI Driver for PowerScale](https://hub.docker.com/r/dellemc/csi-isilon/tags)                |  v2.6.1   |      v2.5.0       |      v2.4.0       |       v2.3.0        |
+| [CSI Driver for Unity XT](https://hub.docker.com/r/dellemc/csi-unity/tags)                   |  v2.6.0   |      v2.5.0       |      v2.4.0       |       v2.3.0        |
+| [CSI Driver for PowerStore](https://hub.docker.com/r/dellemc/csi-powerstore/tags)            |  v2.6.0   |      v2.5.1       |      v2.4.0       |       v2.3.0        |
+| [CSI Driver for PowerFlex](https://hub.docker.com/r/dellemc/csi-vxflexos/tags)               |  v2.6.0   |      v2.5.0       |      v2.4.0       |       v2.3.0        |
+| [CSI Driver for PowerMax](https://hub.docker.com/r/dellemc/csi-powermax/tags)                |  v2.6.0   |      v2.5.0       |      v2.4.0       |       v2.3.1        |
 
 ## CSM Modules Support Matrix for Dell CSI Drivers 
 
-| CSM Module                                                  | CSI PowerFlex v2.6.0 | CSI PowerScale v2.6.0 | CSI PowerStore v2.6.0 | CSI PowerMax v2.6.0 | CSI Unity XT v2.6.0 |
+| CSM Module                                                  | CSI PowerFlex v2.6.0 | CSI PowerScale v2.6.1 | CSI PowerStore v2.6.0 | CSI PowerMax v2.6.0 | CSI Unity XT v2.6.0 |
 | ----------------------------------------------------------- | -------------------- | --------------------- | --------------------- | ------------------- | ------------------- |
 | [**Authorization**](authorization/) v1.6.0                  | ✔️                    | ✔️                     | ❌                     | ✔️                   | ❌                   |
 | [**Observability**](observability/) v1.5.0                  | ✔️                    | ✔️                     | ✔️                     | ✔️                   | ❌                   |

--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -33,7 +33,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 {{<table "table table-striped table-bordered table-sm">}}
 | Features                 | PowerMax | PowerFlex | Unity XT  | PowerScale | PowerStore |
 |--------------------------|:--------:|:---------:|:---------:|:----------:|:----------:|
-| CSI Driver version       | 2.6.0    | 2.6.0     | 2.6.0     | 2.6.0      | 2.6.0      |
+| CSI Driver version       | 2.6.0    | 2.6.0     | 2.6.0     | 2.6.1      | 2.6.0      |
 | Static Provisioning      | yes      | yes       | yes       | yes        | yes        |
 | Dynamic Provisioning     | yes      | yes       | yes       | yes        | yes        |
 | Expand Persistent Volume | yes      | yes       | yes       | yes        | yes        |

--- a/content/docs/csidriver/installation/helm/isilon.md
+++ b/content/docs/csidriver/installation/helm/isilon.md
@@ -125,7 +125,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
 ## Install the Driver
 
 **Steps**
-1. Run `git clone -b v2.6.0 https://github.com/dell/csi-powerscale.git` to clone the git repository.
+1. Run `git clone -b v2.6.1 https://github.com/dell/csi-powerscale.git` to clone the git repository.
 2. Ensure that you have created the namespace where you want to install the driver. You can run `kubectl create namespace isilon` to create a new one. The use of "isilon"  as the namespace is just an example. You can choose any name for the namespace.
 3. Collect information from the PowerScale Systems like IP address, IsiPath, username, and password. Make a note of the value for these parameters as they must be entered in the *secret.yaml*.
 4. Copy *the helm/csi-isilon/values.yaml* into a new location with name say *my-isilon-settings.yaml*, to customize settings for installation.

--- a/content/docs/csidriver/release/powerscale.md
+++ b/content/docs/csidriver/release/powerscale.md
@@ -3,7 +3,7 @@ title: PowerScale
 description: Release notes for PowerScale CSI driver
 ---
 
-## Release Notes - CSI Driver for PowerScale v2.6.0
+## Release Notes - CSI Driver for PowerScale v2.6.1
 
 ### New Features/Changes
 
@@ -14,7 +14,9 @@ description: Release notes for PowerScale CSI driver
 
 ### Fixed Issues
 
-There are no fixed issues in this release.
+| Github ID                                     | Description                                                      |
+| --------------------------------------------- | ---------------------------------------------------------------- |
+| [753](https://github.com/dell/csm/issues/753) | **Replication:** Incorrect quota set on the target PV/directory. |
 
 ### Known Issues
 | Issue                                                                                                                                                                                                                               | Resolution or workaround, if known                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |

--- a/content/docs/csidriver/release/powerscale.md
+++ b/content/docs/csidriver/release/powerscale.md
@@ -14,9 +14,9 @@ description: Release notes for PowerScale CSI driver
 
 ### Fixed Issues
 
-| Github ID                                     | Description                                                      |
-| --------------------------------------------- | ---------------------------------------------------------------- |
-| [753](https://github.com/dell/csm/issues/753) | **Replication:** Incorrect quota set on the target PV/directory. |
+| Github ID                                     | Description                                                                            |
+| --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [753](https://github.com/dell/csm/issues/753) | **Replication:** Incorrect quota set on the target PV/directory when Quota is enabled. |
 
 ### Known Issues
 | Issue                                                                                                                                                                                                                               | Resolution or workaround, if known                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |

--- a/content/docs/csidriver/upgradation/drivers/isilon.md
+++ b/content/docs/csidriver/upgradation/drivers/isilon.md
@@ -8,12 +8,12 @@ Description: Upgrade PowerScale CSI driver
 ---
 You can upgrade the CSI Driver for Dell PowerScale using Helm or Dell CSI Operator.
 
-## Upgrade Driver from version 2.5.0 to 2.6.0 using Helm
+## Upgrade Driver from version 2.5.0 to 2.6.1 using Helm
 
 **Note:** While upgrading the driver via helm, controllerCount variable in myvalues.yaml can be at most one less than the number of worker nodes.
 
 **Steps**
-1. Clone the repository using `git clone -b v2.6.0 https://github.com/dell/csi-powerscale.git`, copy the helm/csi-isilon/values.yaml into a new location with a custom name say _my-isilon-settings.yaml_, to customize settings for installation. Edit _my-isilon-settings.yaml_ as per the requirements.
+1. Clone the repository using `git clone -b v2.6.1 https://github.com/dell/csi-powerscale.git`, copy the helm/csi-isilon/values.yaml into a new location with a custom name say _my-isilon-settings.yaml_, to customize settings for installation. Edit _my-isilon-settings.yaml_ as per the requirements.
 2. Change to directory dell-csi-helm-installer to install the Dell PowerScale `cd dell-csi-helm-installer`
 3. Upgrade the CSI Driver for Dell PowerScale using following command:
 


### PR DESCRIPTION
# Description

- Updated CSI PowerScale version from 2.6.0 to 2.6.1 and CSM version from 1.6.0 to 1.6.1
- Added Fixed issue (replication) to PowerScale driver.
- Changes from PR https://github.com/dell/csm-docs/pull/569 will eventually move over here after 1.6.1 branch is rebased from main.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/753 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

