### PR TITLE
Update 1.6 to 1.6.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -169,7 +169,7 @@ enable = false
 #	icon = "fa fa-envelope"
 #        desc = "Discuss development issues around the project"
 [[params.versions]]
-  version = "Current(v1.6)"
+  version = "Current(v1.6.1)"
   url = "https://dell.github.io/csm-docs/docs/"
 
 [[params.versions]]


### PR DESCRIPTION
Updating Docs version from 1.6 to 1.6.1 for the release 1.6.1 branch https://github.com/dell/csm-docs/pull/580