### PR TITLE
copy-button-for-observability-pages

### DIFF
--- a/content/docs/observability/_index.md
+++ b/content/docs/observability/_index.md
@@ -114,7 +114,7 @@ Logs can be viewed by using the `kubectl logs` CLI command to output logs for a 
 
 For example, the following script will capture logs of all Pods in the CSM namespace and save the output to one file per Pod.
 
-```
+```bash
 #!/bin/bash
 
 namespace=[CSM_NAMESPACE]

--- a/content/docs/observability/deployment/_index.md
+++ b/content/docs/observability/deployment/_index.md
@@ -100,6 +100,7 @@ Here is a sample minimal configuration for Prometheus. Please note that the conf
     On your terminal, run each of the commands below:
 
     ```terminal
+
     helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
     helm repo add stable https://charts.helm.sh/stable
     helm repo update
@@ -110,6 +111,7 @@ Here is a sample minimal configuration for Prometheus. Please note that the conf
     On your terminal, run the command below:
 
     ```terminal
+
     helm install prometheus prometheus-community/prometheus -n [CSM_NAMESPACE] -f prometheus-values.yaml
     ```
 
@@ -263,6 +265,7 @@ Below are the steps to deploy a new Grafana instance into your Kubernetes cluste
     On your terminal, run the commands below:
 
     ```terminal
+
     helm install grafana grafana/grafana -n [CSM_NAMESPACE] -f grafana-values.yaml
     ```
 
@@ -373,6 +376,7 @@ CSM for Observability is instrumented to report trace data to [Zipkin](https://z
     Update the ConfigMaps from the [table above](#dynamic-configuration). Here is an example updating the karavi-topology-configmap based on the deployment manifest above.
    
     ```console
+    
     kubectl edit configmap/karavi-topology-configmap -n [CSM_NAMESPACE]
     ```
     
@@ -400,36 +404,42 @@ In this case, all storage system requests made by CSM for Observability will be 
 
 1. Delete the current `proxy-authz-tokens` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret proxy-authz-tokens -n [CSM_NAMESPACE]
+
+    kubectl delete secret proxy-authz-tokens -n [CSM_NAMESPACE]
     ```
 
 2. Copy the `proxy-authz-tokens` Secret from the CSI Driver for Dell PowerFlex to the CSM namespace.
     ```console
-    $ kubectl get secret proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
 ##### CSI Driver for Dell PowerScale
 
 1. Delete the current `isilon-proxy-authz-tokens` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret isilon-proxy-authz-tokens -n [CSM_NAMESPACE] 
+
+    kubectl delete secret isilon-proxy-authz-tokens -n [CSM_NAMESPACE] 
     ```
 
 2. Copy the `isilon-proxy-authz-tokens` Secret from the CSI Driver for Dell PowerScale namespace to the CSM namespace.
     ```console
-    $ kubectl get secret proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/'| sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f
+
+    kubectl get secret proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/'| sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f
     ```
 
 ##### CSI Driver for Dell PowerMax
 
 1. Delete the current `powermax-proxy-authz-tokens` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret powermax-proxy-authz-tokens -n [CSM_NAMESPACE] 
+
+    kubectl delete secret powermax-proxy-authz-tokens -n [CSM_NAMESPACE] 
     ```
 
 2. Copy the `powermax-proxy-authz-tokens` Secret from the CSI Driver for Dell PowerMax namespace to the CSM namespace. 
     ```console
-    $ kubectl get secret proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/'| sed 's/name: proxy-authz-tokens/name: powermax-proxy-authz-tokens/' | kubectl create -f
+
+    kubectl get secret proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/'| sed 's/name: proxy-authz-tokens/name: powermax-proxy-authz-tokens/' | kubectl create -f
     ```
    
 #### Update Storage Systems
@@ -439,36 +449,42 @@ If the list of storage systems managed by a Dell CSI Driver have changed, the fo
 
 1. Delete the current `karavi-authorization-config` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret karavi-authorization-config -n [CSM_NAMESPACE]
+
+    kubectl delete secret karavi-authorization-config -n [CSM_NAMESPACE]
     ```
 
 2. Copy the `karavi-authorization-config` Secret from the CSI Driver for Dell PowerFlex namespace to CSM for Observability namespace.
     ```console
-    $ kubectl get secret karavi-authorization-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret karavi-authorization-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
 ##### CSI Driver for Dell PowerScale
 
 1. Delete the current `isilon-karavi-authorization-config` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret isilon-karavi-authorization-config -n [CSM_NAMESPACE]
+
+    kubectl delete secret isilon-karavi-authorization-config -n [CSM_NAMESPACE]
     ```
 
 2. Copy the `isilon-karavi-authorization-config` Secret from the CSI Driver for Dell PowerScale namespace to CSM for Observability namespace.
     ```console
-    $ kubectl get secret karavi-authorization-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | kubectl create -f
+
+    kubectl get secret karavi-authorization-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | kubectl create -f
     ```
 
 ##### CSI Driver for Dell PowerMax
 
 1. Delete the current `powermax-karavi-authorization-config` secret from the CSM namespace.
    ```console
-   $ kubectl delete secret powermax-karavi-authorization-config -n [CSM_NAMESPACE]
+
+   kubectl delete secret powermax-karavi-authorization-config -n [CSM_NAMESPACE]
    ```
 
 2. Copy `powermax-karavi-authorization-config` secret from the CSI Driver for Dell PowerMax to the CSM namespace.
    ```console
-   $ kubectl get secret karavi-authorization-config proxy-server-root-certificate -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: powermax-karavi-authorization-config/' | kubectl create -f - 
+
+   kubectl get secret karavi-authorization-config proxy-server-root-certificate -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: powermax-karavi-authorization-config/' | kubectl create -f - 
    ```
 
 ### When CSM for Observability does not use the Authorization module
@@ -479,57 +495,65 @@ In this case all storage system requests made by CSM for Observability will not 
 
 1. Delete the current `vxflexos-config` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret vxflexos-config -n [CSM_NAMESPACE]
+    kubectl delete secret vxflexos-config -n [CSM_NAMESPACE]
     ```
 
 2. Copy the `vxflexos-config` Secret from the CSI Driver for Dell PowerFlex namespace to the CSM namespace.
     ```console
-    $ kubectl get secret vxflexos-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret vxflexos-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
    If the CSI driver secret name is not the default `vxflexos-config`, please use the following command to copy secret:
     ```console
-    $ kubectl get secret [VXFLEXOS-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG]/name: vxflexos-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret [VXFLEXOS-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG]/name: vxflexos-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
 #### CSI Driver for Dell PowerStore
 
 1. Delete the current `powerstore-config` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret powerstore-config -n [CSM_NAMESPACE]
+
+    kubectl delete secret powerstore-config -n [CSM_NAMESPACE]
     ```
 
 2. Copy the `powerstore-config` Secret from the CSI Driver for Dell PowerStore namespace to the CSM namespace.
     ```console
-    $ kubectl get secret powerstore-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret powerstore-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
    If the CSI driver secret name is not the default `powerstore-config`, please use the following command to copy secret:
     ```console
-    $ kubectl get secret [POWERSTORE-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERSTORE-CONFIG]/name: powerstore-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret [POWERSTORE-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERSTORE-CONFIG]/name: powerstore-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
 #### CSI Driver for Dell PowerScale
 
 1. Delete the current `isilon-creds` Secret from the CSM namespace.
     ```console
-    $ kubectl delete secret isilon-creds -n [CSM_NAMESPACE]
+    kubectl delete secret isilon-creds -n [CSM_NAMESPACE]
     ```
 
 2. Copy the `isilon-creds` Secret from the CSI Driver for Dell PowerScale namespace to the CSM namespace.
     ```console
-    $ kubectl get secret isilon-creds -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret isilon-creds -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     If the CSI driver secret name is not the default `isilon-creds`, please use the following command to copy secret:  
     ```console
-    $ kubectl get secret [ISILON-CREDS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CREDS]/name: isilon-creds/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+    kubectl get secret [ISILON-CREDS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CREDS]/name: isilon-creds/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
 #### CSI Driver for Dell PowerMax
 
 1. Delete the secrets in `powermax-reverseproxy-config` configmap from the CSM namespace. 
    ```console
+
    for secret in $(kubectl get configmap powermax-reverseproxy-config -n [CSM_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
    do
       kubectl delete secret $secret -n [CSM_NAMESPACE]
@@ -538,23 +562,27 @@ In this case all storage system requests made by CSM for Observability will not 
 
 2. Delete the current `powermax-reverseproxy-config` configmap from the CSM namespace.
    ```console
-   $ kubectl delete configmap powermax-reverseproxy-config -n [CSM_NAMESPACE] 
+
+   kubectl delete configmap powermax-reverseproxy-config -n [CSM_NAMESPACE] 
    ```
 
 3. Copy the configmap `powermax-reverseproxy-config` from the CSI Driver for Dell PowerMax namespace to the CSM namespace.  
    __Note:__ Observability for PowerMax works only with [CSI PowerMax driver with Proxy in StandAlone mode](../../csidriver/installation/helm/powermax/#csi-powermax-driver-with-proxy-in-standalone-mode).
    ```console
-   $ kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+   kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
    ```
 
    If the CSI driver configmap name is not the default `powermax-reverseproxy-config`, please use the following command to copy configmap:
 
    ```console
-   $ kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-REVERSEPROXY-CONFIG]/name: powermax-reverseproxy-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+
+   kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-REVERSEPROXY-CONFIG]/name: powermax-reverseproxy-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
    ```
 
 4. Copy the secrets in `powermax-reverseproxy-config` from the CSI Driver for Dell PowerMax namespace to the CSM namespace.  
     ```console
+
     for secret in $(kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
     do
        kubectl get secret $secret -n [CSI_DRIVER_NAMESPACE] -o yaml | sed "s/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/" | kubectl create -f -
@@ -563,6 +591,7 @@ In this case all storage system requests made by CSM for Observability will not 
 
     If the CSI driver configmap name is not the default `powermax-reverseproxy-config`, please use the following command to copy secrets:
     ```console
+
     for secret in $(kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
     do
        kubectl get secret $secret -n [CSI_DRIVER_NAMESPACE] -o yaml | sed "s/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/" | kubectl create -f -

--- a/content/docs/observability/deployment/helm.md
+++ b/content/docs/observability/deployment/helm.md
@@ -15,11 +15,21 @@ The Container Storage Modules (CSM) for Observability Helm chart bootstraps an O
 
 ## Install the CSM for Observability Helm Chart
 **Steps**
-1. Create a namespace where you want to install the module `kubectl create namespace karavi`
+1. Create a namespace where you want to install the module 
+   ```bash
+   kubectl create namespace karavi
+   ```
 
-2. Install cert-manager CRDs `kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml`
+2. Install cert-manager CRDs 
+   ```bash
 
-3. Add the Dell Helm Charts repo `helm repo add dell https://dell.github.io/helm-charts`
+   kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
+   ```
+
+3. Add the Dell Helm Charts repo 
+   ```bash
+     helm repo add dell https://dell.github.io/helm-charts
+   ```
 
 4. Copy only the deployed CSI driver entities to the Observability namespace
 
@@ -27,73 +37,116 @@ The Container Storage Modules (CSM) for Observability Helm chart bootstraps an O
 
     1. Copy the config Secret from the CSI PowerFlex namespace into the CSM for Observability namespace:
 
-       `kubectl get secret vxflexos-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get secret vxflexos-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
        If the CSI driver secret name is not the default `vxflexos-config`, please use the following command to copy secret:
 
-       `kubectl get secret [VXFLEXOS-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG]/name: vxflexos-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get secret [VXFLEXOS-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG]/name: vxflexos-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
     If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerFlex, perform the following steps:
 
     2. Copy the driver configuration parameters ConfigMap from the CSI PowerFlex namespace into the CSM for Observability namespace:
     
-       `kubectl get configmap vxflexos-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get configmap vxflexos-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
    
        If the CSI driver configmap name is not the default `vxflexos-config-params`, please use the following command to copy configmap:
 
-       `kubectl get configmap [VXFLEXOS-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG-PARAMS]/name: vxflexos-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get configmap [VXFLEXOS-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG-PARAMS]/name: vxflexos-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
     3. Copy the `karavi-authorization-config`, `proxy-server-root-certificate`, `proxy-authz-tokens` Secret from the CSI PowerFlex namespace into the CSM for Observability namespace:
 
-        `kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+        ```bash
+        
+        kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+        ```
 
     ### PowerStore
 
     1. Copy the config Secret from the CSI PowerStore namespace into the CSM for Observability namespace:
 
-       `kubectl get secret powerstore-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get secret powerstore-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
        If the CSI driver secret name is not the default `powerstore-config`, please use the following command to copy secret:  
 
-       `kubectl get secret [POWERSTORE-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERSTORE-CONFIG]/name: powerstore-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get secret [POWERSTORE-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERSTORE-CONFIG]/name: powerstore-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
    
     ### PowerScale
 
     1. Copy the config Secret from the CSI PowerScale namespace into the CSM for Observability namespace:
 
-       `kubectl get secret isilon-creds -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get secret isilon-creds -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
    
        If the CSI driver secret name is not the default `isilon-creds`, please use the following command to copy secret:  
 
-       `kubectl get secret [ISILON-CREDS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CREDS]/name: isilon-creds/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get secret [ISILON-CREDS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CREDS]/name: isilon-creds/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
     If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerScale, perform these steps:
 
     2. Copy the driver configuration parameters ConfigMap from the CSI PowerScale namespace into the CSM for Observability namespace:
 
-       `kubectl get configmap isilon-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+
+       kubectl get configmap isilon-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
    
        If the CSI driver configmap name is not the default `isilon-config-params`, please use the following command to copy configmap:
 
-       `kubectl get configmap [ISILON-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CONFIG-PARAMS]/name: isilon-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get configmap [ISILON-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CONFIG-PARAMS]/name: isilon-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
     3. Copy the `karavi-authorization-config`, `proxy-server-root-certificate`, `proxy-authz-tokens` Secret from the CSI PowerScale namespace into the CSM for Observability namespace:
 
-       `kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: isilon-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f -`  
+       ```bash
+       
+       kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: isilon-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f -
+       ```  
 
     ### PowerMax
 
     1. Copy the configmap `powermax-reverseproxy-config` from the CSI Driver for Dell PowerMax namespace to the CSM namespace.  
        __Note:__ Observability for PowerMax works only with [CSI PowerMax driver with Proxy in StandAlone mode](../../../csidriver/installation/helm/powermax/#csi-powermax-driver-with-proxy-in-standalone-mode).  
 
-       `kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+
+       kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
    
        If the CSI driver configmap name is not the default `powermax-reverseproxy-config`, please use the following command to copy configmap:
 
-       `kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-REVERSEPROXY-CONFIG]/name: powermax-reverseproxy-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-REVERSEPROXY-CONFIG]/name: powermax-reverseproxy-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
     2. Copy the secrets in `powermax-reverseproxy-config` from the CSI Driver for Dell PowerMax namespace to the CSM namespace.  
        ```console
+
        for secret in $(kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
        do
           kubectl get secret $secret -n [CSI_DRIVER_NAMESPACE] -o yaml | sed "s/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/" | kubectl create -f -
@@ -102,50 +155,62 @@ The Container Storage Modules (CSM) for Observability Helm chart bootstraps an O
        
        If the CSI driver configmap name is not the default `powermax-reverseproxy-config`, please use the following command to copy secrets:
        ```console
+
        for secret in $(kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
        do
           kubectl get secret $secret -n [CSI_DRIVER_NAMESPACE] -o yaml | sed "s/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/" | kubectl create -f -
        done
        ```
 
-    If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerMax, perform these steps:
+       If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerMax, perform these steps:
 
     3. Copy the driver configuration parameters ConfigMap from the CSI PowerMax namespace into the CSM for Observability namespace:
 
-       `kubectl get configmap powermax-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+
+       kubectl get configmap powermax-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
    
        If the CSI driver configmap name is not the default `powermax-config-params`, please use the following command to copy configmap:  
 
-       `kubectl get configmap [POWERMAX-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-CONFIG-PARAMS]/name: powermax-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -`
+       ```bash
+       
+       kubectl get configmap [POWERMAX-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-CONFIG-PARAMS]/name: powermax-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+       ```
 
     4. Copy the `karavi-authorization-config`, `proxy-server-root-certificate`, `proxy-authz-tokens` Secret from the CSI PowerMax namespace into the CSM for Observability namespace:
 
-       `kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: powermax-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: powermax-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: powermax-proxy-authz-tokens/' | kubectl create -f -` 
+       ```bash
+       
+       kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: powermax-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: powermax-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: powermax-proxy-authz-tokens/' | kubectl create -f -
+       ``` 
 
 
-5. Configure the [parameters](#configuration) and install the CSM for Observability Helm Chart
+    5. Configure the [parameters](#configuration) and install the CSM for Observability Helm Chart
 
-    A default values.yaml file is located [here](https://github.com/dell/helm-charts/blob/main/charts/karavi-observability/values.yaml) that can be used for installation. This can be copied into a file named `myvalues.yaml` and either used as is or modified accordingly. 
+       A default values.yaml file is located [here](https://github.com/dell/helm-charts/blob/main/charts/karavi-observability/values.yaml) that can be used for installation. This can be copied into a file named `myvalues.yaml` and either used as is or modified accordingly. 
 
-    __Note:__ 
-    - The default `values.yaml` is configured to deploy the CSM for Observability Topology service on install.
-    - If CSM for Authorization is enabled for CSI PowerFlex, the `karaviMetricsPowerflex.authorization` parameters must be properly configured in your values file for CSM Observability. 
-    - If CSM for Authorization is enabled for CSI PowerScale, the `karaviMetricsPowerscale.authorization` parameters must be properly configured in your values file for CSM Observability.
-    - If CSM for Authorization is enabled for CSI PowerMax, the `karaviMetricsPowermax.authorization` parameters must be properly configured in your values file for CSM Observability.
+       __Note:__ 
+       - The default `values.yaml` is configured to deploy the CSM for Observability Topology service on install.
+       - If CSM for Authorization is enabled for CSI PowerFlex, the `karaviMetricsPowerflex.authorization` parameters must be properly configured in your values file for CSM Observability. 
+       - If CSM for Authorization is enabled for CSI PowerScale, the `karaviMetricsPowerscale.authorization` parameters must be properly configured in your values file for CSM Observability.
+       - If CSM for Authorization is enabled for CSI PowerMax, the `karaviMetricsPowermax.authorization` parameters must be properly configured in your values file for CSM Observability.
 
-    ```console
-    $ helm install karavi-observability dell/karavi-observability -n [CSM_NAMESPACE] -f myvalues.yaml
-    ```
+       ```console
 
-    Alternatively, you can specify each parameter using the '--set key=value[,key=value]' and/or '--set-file key=value[,key=value] arguments to 'helm install'. For example:
+       helm install karavi-observability dell/karavi-observability -n [CSM_NAMESPACE] -f myvalues.yaml
+       ```
 
-    ```console
-    $ helm install karavi-observability dell/karavi-observability -n [CSM_NAMESPACE] \
+       Alternatively, you can specify each parameter using the '--set key=value[,key=value]' and/or '--set-file key=value[,key=value] arguments to 'helm install'. For example:
+
+       ```console
+
+       helm install karavi-observability dell/karavi-observability -n [CSM_NAMESPACE] \
         --set-file karaviTopology.certificateFile=<location-of-karavi-topology-certificate-file> \
         --set-file karaviTopology.privateKeyFile=<location-of-karavi-topology-private-key-file> \
         --set-file otelCollector.certificateFile=<location-of-otel-collector-certificate-file> \
         --set-file otelCollector.privateKeyFile=<location-of-otel-collector-private-key-file>
-    ```
+       ```
 
 ## Configuration
 

--- a/content/docs/observability/deployment/offline.md
+++ b/content/docs/observability/deployment/offline.md
@@ -40,27 +40,30 @@ To perform an offline installation of a Helm chart, the following steps should b
 
 1. Copy the `offline-installer.sh` script to a local Linux system using `curl` or `wget`:
 
-    ```
-    [user@anothersystem /home/user]# curl https://raw.githubusercontent.com/dell/karavi-observability/main/installer/offline-installer.sh --output offline-installer.sh
+    ```bash
+
+    curl https://raw.githubusercontent.com/dell/karavi-observability/main/installer/offline-installer.sh --output offline-installer.sh
     ```
 
     or
 
-    ```
-    [user@anothersystem /home/user]# wget -O offline-installer.sh https://raw.githubusercontent.com/dell/karavi-observability/main/installer/offline-installer.sh
+    ```bash
+
+    wget -O offline-installer.sh https://raw.githubusercontent.com/dell/karavi-observability/main/installer/offline-installer.sh
     ```
 
 2. Set the file as executable.
 
-    ```
-    [user@anothersystem /home/user]# chmod +x offline-installer.sh
+    ```bash
+    chmod +x offline-installer.sh
     ```
 
 3. Build the bundle by providing the Helm chart name as the argument. Below is a sample output that may be different on your machine. 
 
+    ```bash
+    ./offline-installer.sh -c dell/karavi-observability
     ```
-    [user@anothersystem /home/user]# ./offline-installer.sh -c dell/karavi-observability
-
+    ```
     *
     * Adding Helm repository https://dell.github.io/helm-charts
 
@@ -88,21 +91,22 @@ To perform an offline installation of a Helm chart, the following steps should b
 
 1. Copy the bundle file to another Linux system that has access to the internal Docker registry and that can install the Helm chart. From that Linux system, unpack the bundle.
 
-    ```
-    [user@anothersystem /home/user]# tar -xzf offline-karavi-observability-bundle.tar.gz
+    ```bash
+    tar -xzf offline-karavi-observability-bundle.tar.gz
     ```
 
 2. Change directory into the new directory created from unpacking the bundle:
 
-    ```
-    [user@anothersystem /home/user]# cd offline-karavi-observability-bundle
+    ```bash
+    cd offline-karavi-observability-bundle
     ```
 
 3. Prepare the bundle by providing the internal Docker registry URL. Below is a sample output that may be different on your machine.
 
+    ```bash
+    ./offline-installer.sh -p <my-registry>:5000
     ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle]# ./offline-installer.sh -p <my-registry>:5000
-      
+    ```  
     *
     * Loading, tagging, and pushing Docker images to registry <my-registry>:5000/
 
@@ -118,13 +122,13 @@ To perform an offline installation of a Helm chart, the following steps should b
 ### Perform Helm installation
 
 1. Change directory to `helm` which contains the updated Helm chart directory:
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle]# cd helm
+    ```bash
+    cd helm
     ```
 
 2. Install necessary cert-manager CustomResourceDefinitions provided:
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl apply --validate=false -f cert-manager.crds.yaml
+    ```bash
+    kubectl apply --validate=false -f cert-manager.crds.yaml
     ```
 
 3. Copy the CSI Driver Secret(s) 
@@ -132,83 +136,98 @@ To perform an offline installation of a Helm chart, the following steps should b
     Copy the CSI Driver Secret from the namespace where CSI Driver is installed to the namespace where CSM for Observability is to be installed.
 
     __CSI Driver for PowerFlex:__
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret vxflexos-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret vxflexos-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
     
     If the CSI driver secret name is not the default `vxflexos-config`, please use the following command to copy secret:
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret [VXFLEXOS-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG]/name: vxflexos-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret [VXFLEXOS-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG]/name: vxflexos-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerFlex, perform these steps:
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap vxflexos-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get configmap vxflexos-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
    
     If the CSI driver configmap name is not the default `vxflexos-config-params`, please use the following command to copy configmap:
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap [VXFLEXOS-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG-PARAMS]/name: vxflexos-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+   kubectl get configmap [VXFLEXOS-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [VXFLEXOS-CONFIG-PARAMS]/name: vxflexos-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     __CSI Driver for PowerStore:__
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret powerstore-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret powerstore-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     If the CSI driver secret name is not the default `powerstore-config`, please use the following command to copy secret:
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret [POWERSTORE-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERSTORE-CONFIG]/name: powerstore-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret [POWERSTORE-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERSTORE-CONFIG]/name: powerstore-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     __CSI Driver for PowerScale:__
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret isilon-creds -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f - 
+    ```bash
+
+    kubectl get secret isilon-creds -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f - 
     ```
    
     If the CSI driver secret name is not the default `isilon-creds`, please use the following command to copy secret:
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret [ISILON-CREDS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CREDS]/name: isilon-creds/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret [ISILON-CREDS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CREDS]/name: isilon-creds/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerScale, perform these steps:
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap isilon-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get configmap isilon-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
    
     If the CSI driver configmap name is not the default `isilon-config-params`, please use the following command to copy configmap:
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap [ISILON-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CONFIG-PARAMS]/name: isilon-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get configmap [ISILON-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [ISILON-CONFIG-PARAMS]/name: isilon-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: isilon-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: isilon-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: isilon-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: isilon-proxy-authz-tokens/' | kubectl create -f -
     ``` 
 
     __CSI Driver for PowerMax:__
 
     Copy the configmap from the CSI Driver for Dell PowerMax namespace to the CSM namespace.  
     __Note:__ Observability for PowerMax works only with [CSI PowerMax driver with Proxy in StandAlone mode](../../../csidriver/installation/helm/powermax/#csi-powermax-driver-with-proxy-in-standalone-mode).
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     If the CSI driver configmap name is not the default `powermax-reverseproxy-config`, please use the following command to copy configmap:
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-REVERSEPROXY-CONFIG]/name: powermax-reverseproxy-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+    
+    kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-REVERSEPROXY-CONFIG]/name: powermax-reverseproxy-config/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```   
 
     Copy the secrets from the CSI Driver for Dell PowerMax namespace to the CSM namespace.
-    ```
+    ```bash
+
     for secret in $(kubectl get configmap powermax-reverseproxy-config -n [CSI_DRIVER_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
     do
        kubectl get secret $secret -n [CSI_DRIVER_NAMESPACE] -o yaml | sed "s/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/" | kubectl create -f -
@@ -217,6 +236,7 @@ To perform an offline installation of a Helm chart, the following steps should b
 
     If the CSI driver configmap name is not the default `powermax-reverseproxy-config`, please use the following command to copy secrets:
     ```console
+
     for secret in $(kubectl get configmap [POWERMAX-REVERSEPROXY-CONFIG] -n [CSI_DRIVER_NAMESPACE] -o jsonpath="{.data.config\.yaml}" | grep arrayCredentialSecret | awk 'BEGIN{FS=":"}{print $2}' | uniq)
     do
        kubectl get secret $secret -n [CSI_DRIVER_NAMESPACE] -o yaml | sed "s/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/" | kubectl create -f -
@@ -225,18 +245,21 @@ To perform an offline installation of a Helm chart, the following steps should b
 
     If [CSM for Authorization is enabled](../../../authorization/deployment/#configuring-a-dell-csi-driver-with-csm-for-authorization) for CSI PowerMax, perform these steps:
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap powermax-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get configmap powermax-config-params -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
     If the CSI driver configmap name is not the default `powermax-config-params`, please use the following command to copy configmap:  
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get configmap [POWERMAX-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-CONFIG-PARAMS]/name: powermax-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
+    ```bash
+
+    kubectl get configmap [POWERMAX-CONFIG-PARAMS] -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/name: [POWERMAX-CONFIG-PARAMS]/name: powermax-config-params/' | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | kubectl create -f -
     ```
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: powermax-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: powermax-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: powermax-proxy-authz-tokens/' | kubectl create -f -
+    ```bash
+
+    kubectl get secret karavi-authorization-config proxy-server-root-certificate proxy-authz-tokens -n [CSI_DRIVER_NAMESPACE] -o yaml | sed 's/namespace: [CSI_DRIVER_NAMESPACE]/namespace: [CSM_NAMESPACE]/' | sed 's/name: karavi-authorization-config/name: powermax-karavi-authorization-config/' | sed 's/name: proxy-server-root-certificate/name: powermax-proxy-server-root-certificate/' | sed 's/name: proxy-authz-tokens/name: powermax-proxy-authz-tokens/' | kubectl create -f -
     ``` 
 
 4. Now that the required images have been made available and the Helm chart's configuration updated with references to the internal registry location, installation can proceed by following the instructions that are documented within the Helm chart's repository.  
@@ -248,8 +271,9 @@ To perform an offline installation of a Helm chart, the following steps should b
     - If CSM for Authorization is enabled for CSI PowerScale, the `karaviMetricsPowerscale.authorization` parameters must be properly configured.
     - If CSM for Authorization is enabled for CSI PowerMax, the `karaviMetricsPowermax.authorization` parameters must be properly configured.
 
-    ```
-    [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# helm install -n install-namespace app-name karavi-observability
+    ```bash
+
+    helm install -n install-namespace app-name karavi-observability
 
     NAME: app-name
     LAST DEPLOYED: Fri Nov  6 08:48:13 2020

--- a/content/docs/observability/deployment/online.md
+++ b/content/docs/observability/deployment/online.md
@@ -55,9 +55,10 @@ A Linux-based system, with internet access, will be used to execute the script t
 
 
 ### Installer Usage
+```bash
+./karavi-observability-install.sh --help
 ```
-[user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh --help
-
+```
 Help for ./karavi-observability-install.sh
 
 Usage: ./karavi-observability-install.sh mode options...
@@ -88,13 +89,13 @@ __Note:__ CSM for Authorization currently does not support the Observability mod
 To perform an online installation of CSM for Observability, the following steps should be performed:
 
 1. Clone the GitHub repository:
-    ```
-    [user@system /home/user]# git clone https://github.com/dell/karavi-observability.git
+    ```bash
+    git clone https://github.com/dell/karavi-observability.git
     ```
 
 2. Change to the installer directory:
-    ```
-    [user@system /home/user]# cd karavi-observability/installer
+    ```bash
+    cd karavi-observability/installer
     ```
 
 3. Execute the installation script.
@@ -108,8 +109,11 @@ To perform an online installation of CSM for Observability, the following steps 
     - If CSM for Authorization is enabled for CSI PowerScale, the `karaviMetricsPowerscale.authorization` parameters must be properly configured in `myvalues.yaml` for CSM Observability.
     - If CSM for Authorization is enabled for CSI PowerMax, the `karaviMetricsPowermax.authorization` parameters must be properly configured in `myvalues.yaml` for CSM Observability.
 
+    ```bash
+    
+    ./karavi-observability-install.sh install --namespace [CSM_NAMESPACE] --values myvalues.yaml
     ```
-    [user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh install --namespace [CSM_NAMESPACE] --values myvalues.yaml
+    ```
     ---------------------------------------------------------------------------------
     > Installing Karavi Observability in namespace karavi on 1.21
     ---------------------------------------------------------------------------------

--- a/content/docs/observability/troubleshooting/_index.md
+++ b/content/docs/observability/troubleshooting/_index.md
@@ -25,7 +25,7 @@ This issue can arise when the topology service manifest is updated to expose the
 
 A user who tries to connect to `karavi-topology` on any browser may receive an error/warning message about the certificate. The message may vary depending on the browser. For instance, in Internet Explorer, you'll see:
 
-```console
+```
 There is a problem with this website's security certificate. 
 The security certificate presented by this website was not
 issued by a trusted certificate authority
@@ -38,7 +38,9 @@ While this certificate problem may indicate an attempt to fool you or intercept 
 A user who tries to connect to `karavi-topology` by using `curl` may receive the following warning or error message:
 
 ```console
-[root@:~]$ curl -v https://<karavi-topology-cluster-IP>:<port?/query
+curl -v https://<karavi-topology-cluster-IP>:<port?/query
+```
+```
 *   Trying ***********...
 * TCP_NODELAY set
 * Connected to *********** (***********) port 31433 (#0)
@@ -70,7 +72,9 @@ how to fix it, please visit the web page mentioned above.
 Due to the error above, the client pings the topology server with a **TLS handshake error** which is logged in `karavi-topology` pod. For instance,
 
 ```console
-[root@:~]$ kubectl  logs  -n powerflex karavi-topology-5d4669d6dd-trzxw
+kubectl  logs  -n powerflex karavi-topology-5d4669d6dd-trzxw
+```
+```
 2021/04/27 09:38:28 Set DriverNames to [csi-vxflexos.dellemc.com]
 2021/04/28 07:15:05 http: TLS handshake error from 10.42.0.0:58450: local error: tls: bad record MAC
 2021/04/28 07:16:14 http: TLS handshake error from 10.42.0.0:55311: local error: tls: bad record MAC
@@ -85,7 +89,10 @@ To resolve this issue, we need to configure the client to be aware of the karavi
 If we supplied a custom certificate during installing karavi-topology, we can simply open the `.crt` and copy the text. However, if it was assigned by cert-manager, you can get a copy of the certificate by running the following `kubectl` command on the clusters.
 
 ```console
-[root@:~]$ kubectl -n <namespace> get secret karavi-topology-tls -o jsonpath='{.data.tls\.crt}' | base64 -d
+
+kubectl -n <namespace> get secret karavi-topology-tls -o jsonpath='{.data.tls\.crt}' | base64 -d
+```
+```
 -----BEGIN CERTIFICATE-----
 RaNDOMcErTifCATeRaNDOMcErTifCATe..RaNDOMcErTifCATe
 RaNDOMcErTifCATe..RaNDOMcErTifCATeRaNDOMcErTifCATe
@@ -232,6 +239,8 @@ CSM for Observability is instrumented to report trace data to [Zipkin](https://z
 Check the pods in the CSM for Observability namespace. If the pod starting with 'karavi-observability-cert-manager-cainjector-*' is in 'CrashLoopBackOff' or 'Error" stage with a number of restarts, check if the logs for that pod show the below error:
 ```console
 kubectl logs -n $namespace $cert-manager-cainjector-podname
+```
+```
 error registering secret controller: no matches for kind "MutatingWebhookConfiguration" in version "admissionregistration.k8s.io/v1beta1"
 ```
 
@@ -241,7 +250,9 @@ If the Kubernetes cluster version is 1.22.2 (or higher), this error is due to an
 
 The warning can arise when a self-signed certificate for otel-collector is issued. It takes a few minutes or less for the signed certificate to generate and be consumed in the namespace. Once the certificate is consumed, the FailedMount warnings are resolved and the containers start properly. 
 ```console
-[root@:~]$ kubectl describe pod -n $namespace $pod
+kubectl describe pod -n $namespace $pod
+```
+```
 MountVolume.SetUp failed for volume "tls-secret" : secret "otel-collector-tls" not found
 Unable to attach or mount volumes: unmounted volumes=[tls-secret], unattached volumes=[vxflexos-config-params vxflexos-config tls-secret karavi-metrics-powerflex-configmap kube-api-access-4fqgl karavi-authorization-config proxy-server-root-certificate]: timed out waiting for the condition
 ```
@@ -249,12 +260,14 @@ Unable to attach or mount volumes: unmounted volumes=[tls-secret], unattached vo
 ### Why do I see 'Failed calling webhook' error when reinstalling CSM for Observability?
 This warning can occur when a user uninstalls Observability by deleting the Kubernetes namespace before properly cleaning up by running `helm delete` on the Observability Helm installation. This results in the credential manager failing to properly integrate with Observability on future installations. The user may see the following error in the module pods upon reinstallation:
 
-```console
+```
 Error: INSTALLATION FAILED: failed to create resource: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://karavi-observability-cert-manager-webhook.karavi-observability.svc:443/mutate?timeout=10s": dial tcp 10.106.44.80:443: connect: connection refused
 ```
 
 To resolve this, leave the CSM namespace in place after a failed installation, and run the below command:
 
- `helm delete karavi-observability --namespace [CSM_NAMESPACE]`
+```bash
+helm delete karavi-observability --namespace [CSM_NAMESPACE]
+```
 
 Then delete the namespace `kubectl delete ns [CSM_NAMESPACE]`. Wait until namespace is fully deleted, recreate the namespace, and reinstall Observability again. 

--- a/content/docs/observability/uninstall/_index.md
+++ b/content/docs/observability/uninstall/_index.md
@@ -13,10 +13,11 @@ This section outlines the uninstallation steps for Container Storage Modules (CS
 The command below removes all the Kubernetes components associated with the chart.
 
 ```console
-$ helm delete karavi-observability --namespace [CSM_NAMESPACE]
+helm delete karavi-observability --namespace [CSM_NAMESPACE]
 ```
 You may also want to uninstall the CRDs created for cert-manager.
 
 ```console
-$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
+
+kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
 ```

--- a/content/docs/observability/upgrade/_index.md
+++ b/content/docs/observability/upgrade/_index.md
@@ -17,14 +17,16 @@ CSM for Observability Helm upgrade supports [Helm](../deployment/helm), [Online 
 
 To upgrade an existing Helm installation of CSM for Observability to the latest release, download the latest Helm charts.
 
-```
+```bash
 helm repo update
 ```
 
 Check if the latest Helm chart version is available:
 
-```
+```bash
 helm search repo dell
+```
+```
 NAME                            CHART VERSION   APP VERSION     DESCRIPTION
 dell/karavi-observability       1.5.0           1.5.0           CSM for Observability is part of the [Container...
 ```
@@ -33,14 +35,16 @@ dell/karavi-observability       1.5.0           1.5.0           CSM for Observab
 
 Upgrade to the latest CSM for Observability release:
 
-```
+
 Upgrade Helm and Online Installer deployments:
+```bash
 
-  $ helm upgrade --version $latest_chart_version --values values.yaml karavi-observability dell/karavi-observability -n $namespace
-
+helm upgrade --version $latest_chart_version --values values.yaml karavi-observability dell/karavi-observability -n $namespace
+```
 Upgrade Offline Installer deployment:
+```bash
 
-  $ helm upgrade --version $latest_chart_version karavi-observability dell/karavi-observability -n $namespace
+helm upgrade --version $latest_chart_version karavi-observability dell/karavi-observability -n $namespace
 ```
 
 The [configuration](../deployment/helm#configuration) section lists all the parameters that can be configured using the `values.yaml` file.
@@ -50,14 +54,17 @@ The [configuration](../deployment/helm#configuration) section lists all the para
 CSM for Observability online installer upgrade can be used if the initial deployment was performed using the [Online Installer](../deployment/online) or [Helm](../deployment/helm).
 
 1. Change to the installer directory:
-    ```
-    [user@system /home/user]# cd karavi-observability/installer
+    ```bash
+    cd karavi-observability/installer
     ```
 2. Update `values.yaml` file as needed. Configuration options are outlined in the [Helm chart deployment section](../deployment/helm#configuration).
 
 3. Execute the `./karavi-observability-install.sh` script:
+    ```bash
+
+    ./karavi-observability-install.sh upgrade --namespace $namespace --values myvalues.yaml --version $latest_chart_version
     ```
-    [user@system /home/user/karavi-observability/installer]# ./karavi-observability-install.sh upgrade --namespace $namespace --values myvalues.yaml --version $latest_chart_version
+    ```
     ---------------------------------------------------------------------------------
     >  Upgrading Karavi Observability in namespace karavi on 1.21
     ---------------------------------------------------------------------------------
@@ -94,12 +101,13 @@ These instructions can be followed when a Helm chart was installed and will be u
 
 3. Perform Helm upgrade
    1. Change directory to `helm` which contains the updated Helm chart directory:
-      ```
-      [user@anothersystem /home/user/offline-karavi-observability-bundle]# cd helm
+      ```bash
+      cd helm
       ```
    2. Install necessary cert-manager CustomResourceDefinitions provided.
-      ```
-      [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# kubectl apply --validate=false -f cert-manager.crds.yaml
+      ```bash
+      
+      kubectl apply --validate=false -f cert-manager.crds.yaml
       ```
    3. (Optional) Enable Karavi Observability for PowerFlex/PowerScale to use an existing instance of Karavi Authorization for accessing the REST API for the given storage systems.  
       **Note**: Assuming that if the Karavi Observability's Authorization has been enabled in the phase of [Offline Karavi Observability Helm Chart Installer](../deployment/offline), the Authorization Secrets/Configmap have been copied to the Karavi Observability namespace.  
@@ -109,8 +117,11 @@ These instructions can be followed when a Helm chart was installed and will be u
    4. Now that the required images have been made available and the Helm chart's configuration updated with references to the internal registry location, installation can proceed by following the instructions that are documented within the Helm chart's repository.  
       **Note**: Assuming that Your Secrets from CSI Drivers have been copied to the Karavi Observability namespace in the phase of [Offline Karavi Observability Helm Chart Installer](../deployment/offline)   
       Optionally, you could provide your own [configurations](../deployment/helm/#configuration). A sample values.yaml file is located [here](https://github.com/dell/helm-charts/blob/main/charts/karavi-observability/values.yaml).
+      ```bash
+
+        helm upgrade -n install-namespace app-name karavi-observability
       ```
-        [user@anothersystem /home/user/offline-karavi-observability-bundle/helm]# helm upgrade -n install-namespace app-name karavi-observability
+      ```  
         NAME: app-name
         LAST DEPLOYED: Wed Aug 17 14:44:04 2022
         NAMESPACE: install-namespace


### PR DESCRIPTION
# Description
Added a copy button on syntax code blocks with prism in Observability Pages. Modified the code-blocks as required for enabling the copy button.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?