### PR TITLE
Fixes for Operator install of Replication

### DIFF
--- a/content/docs/deployment/csmoperator/_index.md
+++ b/content/docs/deployment/csmoperator/_index.md
@@ -5,7 +5,7 @@ description: Container Storage Modules Operator
 weight: 1
 ---
 
-The Dell Container Storage Modules Operator Operator is a Kubernetes Operator, which can be used to install and manage the CSI Drivers and CSM Modules provided by Dell for various storage platforms. This operator is available as a community operator for upstream Kubernetes and can be deployed using OperatorHub.io. The operator can be installed using OLM (Operator Lifecycle Manager) or manually.
+The Dell Container Storage Modules Operator is a Kubernetes Operator, which can be used to install and manage the CSI Drivers and CSM Modules provided by Dell for various storage platforms. This operator is available as a community operator for upstream Kubernetes and can be deployed using OperatorHub.io. The operator can be installed using OLM (Operator Lifecycle Manager) or manually.
 
 ## Supported Platforms
 Dell CSM Operator has been tested and qualified on Upstream Kubernetes and OpenShift. Supported versions are listed below.
@@ -49,11 +49,11 @@ Dell CSM Operator can be installed manually or via Operator Hub.
 5. Run the command `kubectl get pods -n dell-csm-operator` to validate the installation. If installed successfully, you should be able to see the operator pod in the `dell-csm-operator` namespace.
 
 {{< imgproc install_pods.jpg Resize "2500x" >}}{{< /imgproc >}}
-   
+
 ### Installation via Operator Hub
 `dell-csm-operator` can be installed via Operator Hub on upstream Kubernetes clusters & Red Hat OpenShift Clusters.
 
-The installation process involves the creation of a `Subscription` object either via the _OperatorHub_ UI or using `kubectl/oc`. While creating the `Subscription` you can set the Approval strategy for the `InstallPlan` for the operator to: 
+The installation process involves the creation of a `Subscription` object either via the _OperatorHub_ UI or using `kubectl/oc`. While creating the `Subscription` you can set the Approval strategy for the `InstallPlan` for the operator to:
 * _Automatic_ - If you want the operator to be automatically installed or upgraded (once an upgrade is available).
 * _Manual_ - If you want a cluster administrator to manually review and approve the `InstallPlan` for installation/upgrades.
 
@@ -87,13 +87,13 @@ The `Update approval` (**`InstallPlan`** in OLM terms) strategy plays a role whi
 **NOTE**: The recommended version of OLM for Upstream Kubernetes is **`v0.18.3`**.
 
 ### Custom Resource Definitions
-As part of the Dell CSM Operator installation, a CRD representing configuration for the CSI Driver and CSM Modules is also installed.  
+As part of the Dell CSM Operator installation, a CRD representing configuration for the CSI Driver and CSM Modules is also installed.
 `containerstoragemodule` CRD is installed in API Group `storage.dell.com`.
 
 Drivers and modules can be installed by creating a `customResource`.
 
 ### Custom Resource Specification
-Each CSI Driver and CSM Module installation is represented by a Custom Resource.  
+Each CSI Driver and CSM Module installation is represented by a Custom Resource.
 
 The specification for the Custom Resource is the same for all the drivers.Below is a list of all the mandatory and optional fields in the Custom Resource specification
 
@@ -117,7 +117,7 @@ The specification for the Custom Resource is the same for all the drivers.Below 
 
 **node** - List of environment variables and values which are applicable only for node.
 
-**sideCars** - Specification for CSI sidecar containers.  
+**sideCars** - Specification for CSI sidecar containers.
 
 **authSecret** - Name of the secret holding credentials for use by the driver. If not specified, the default secret *-creds must exist in the same namespace as driver.
 
@@ -125,6 +125,6 @@ The specification for the Custom Resource is the same for all the drivers.Below 
 
 **tolerations** - List of tolerations which should be applied to the driver StatefulSet/Deployment and DaemonSet. It should be set separately in the controller and node sections if you want separate set of tolerations for them.
 
-**nodeSelector** - Used to specify node selectors for the driver StatefulSet/Deployment and DaemonSet. 
+**nodeSelector** - Used to specify node selectors for the driver StatefulSet/Deployment and DaemonSet.
 
->**Note:** The `image` field should point to the correct image tag for version of the driver you are installing.  
+>**Note:** The `image` field should point to the correct image tag for version of the driver you are installing.

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -11,11 +11,11 @@ The CSM Replication module for supported Dell CSI Drivers can be installed via t
 To configure Replication prior to installation via CSM Operator, you need:
 
 - a source cluster which is the main cluster
-- a target cluster which will serve as the disaster recovery cluster, a single stretched cluster configuration is also supported
-- the csm-replication GitHub repository is cloned to your source cluster and the [`repctl`](../../../../replication/tools) tool is either built from source or downloaded and in your PATH
+- a target cluster which will serve as the disaster recovery cluster
+> **_NOTE:_**  If using a single Kubernetes cluster in a stretched configuration, there will be only one cluster. The source cluster is also the target cluster.
 
 ### Cloning the GitHub Repository and Building repctl
-On your source cluster run the following to clone and build the repctl tool.
+The [csm-replication](https://github.com/dell/csm-replication.git) GitHub repository is cloned to your source cluster as part of the installation. On your source cluster run the following to clone and build the repctl tool:
 
 ```
 git clone -b v1.4.0 https://github.com/dell/csm-replication.git

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -5,23 +5,47 @@ description: >
   Pre-requisite for Installing Replication via Dell CSM Operator
 ---
 
-The CSM Replication module for supported Dell CSI Drivers can be installed via the Dell CSM Operator. Dell CSM Operator will deploy CSM Replication sidecar and the complemental CSM Replication controller manager.
+The CSM Replication module for supported Dell CSI Drivers can be installed via the Dell CSM Operator. Dell CSM Operator will deploy the CSM Replication sidecar and the CSM Replication Controller Manager.
 
-## Prerequisite
-
-To use Replication, you need at least two clusters:
+## Prerequisites
+To configure Replication prior to installation via CSM Operator, you need:
 
 - a source cluster which is the main cluster
-- one or more target clusters which will serve as diaster recovery clusters for the main cluster
+- a target cluster which will serve as the disaster recovery cluster, a single stretched cluster configuration is also supported
+- the csm-replication GitHub repository is cloned to your source cluster and the [`repctl`](../../../../replication/tools) tool is either built from source or downloaded and in your PATH
 
-To configure all the clusters, follow the steps below:
+### Cloning the GitHub Repository and Building repctl
+On your source cluster run the following to clone and build the repctl tool.
 
-1. On your main cluster, follow the instructions available in CSM Replication for [Installation using repctl](../../../../replication/deployment/install-repctl), with the exception of step 4. When you reach step 4, you MUST use the command below to automatically package all clusters `.kube` config as a secret:           
-
-```shell
-  ./repctl cluster inject 
+```
+git clone -b v1.4.0 https://github.com/dell/csm-replication.git
+cd csm-replication/repctl
+make build
 ```
 
-CSM Operator needs this admin configs instead of the service accounts’ configs  to be able to properly manage the target clusters. The default service account that'll be used is the CSM Operator service account.
+The rest of the instructions will assume that your current working directory is the csm-replication/repctl directory.
+## Configuration Steps
+To configure replication when using multiple clusters:
 
-2. On each of the target clusters, configure the prerequisites for deploying the driver via Dell CSM Operator. For example, PowerScale has the following [prerequisites for deploying PowerScale via Dell CSM Operator](../../drivers/powerscale/#prerequisite)
+1. On your main cluster collect the cluster admin configurations for each of the clusters. In the following example the source cluster, `cluster-1` uses configuration `/root/.kube/config-1` and the target cluster, `cluster-2` uses the configuration `/root/.config/config-2`. Use repctl to add the clusters:
+    ```shell
+      ./repctl cluster add -f "/root/.kube/config-1","/root/.kube/config-2" -n "cluster-1","cluster-2"
+    ```
+  > **_NOTE:_**  If using a single Kubernetes cluster in a stretched configuration there will be only one cluster.
+2. Install the replication controller CRDs:
+    ```shell
+    ./repctl create -f ../deploy/replicationcrds.all.yaml
+    ```
+3. Inject the service account's configuration into the clusters. CSM Operator needs the admin configs instead of the service account configurations to be able to properly manage the target clusters.
+    ```shell
+    ./repctl cluster inject
+    ```
+4. Customize the `examples/<storage>_example_values.yaml` sample config. Set the values for sourceClusterID and targetClusterID to the same names used in step 1. For a stretched cluster set both fields to `self`:
+
+5. Create the replication storage classes using the modified configuration from step 4:
+    ```shell
+    ./repctl create sc --from-config ./examples/<storage>_example_values.yaml
+    ```
+6. On each of the target clusters, configure the [prerequisites](../../../csmoperator/drivers/#pre-requisites-for-installation-of-the-csi-drivers) for deploying the driver via Dell CSM Operator.
+
+7. Install the CSI driver for your chosen storage platform on the source cluster according to the instructions for [installing the drivers using CSM Operator](../../../csmoperator/drivers/#installing-csi-driver-via-operator).

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -25,7 +25,7 @@ make build
 
 The rest of the instructions will assume that your current working directory is the csm-replication/repctl directory.
 ## Configuration Steps
-To configure replication when using multiple clusters:
+To configure Replication perform the following steps:
 
 1. On your main cluster collect the cluster admin configurations for each of the clusters. In the following example the source cluster, `cluster-1` uses configuration `/root/.kube/config-1` and the target cluster, `cluster-2` uses the configuration `/root/.config/config-2`. Use repctl to add the clusters:
     ```shell
@@ -36,7 +36,7 @@ To configure replication when using multiple clusters:
     ```shell
     ./repctl create -f ../deploy/replicationcrds.all.yaml
     ```
-3. Inject the service account's configuration into the clusters. CSM Operator needs the admin configs instead of the service account configurations to be able to properly manage the target clusters.
+3. Inject the service account's configuration into the clusters.
     ```shell
     ./repctl cluster inject
     ```
@@ -46,6 +46,6 @@ To configure replication when using multiple clusters:
     ```shell
     ./repctl create sc --from-config ./examples/<storage>_example_values.yaml
     ```
-6. On each of the target clusters, configure the [prerequisites](../../../csmoperator/drivers/#pre-requisites-for-installation-of-the-csi-drivers) for deploying the driver via Dell CSM Operator.
+6. On the target cluster, configure the [prerequisites](../../../csmoperator/drivers/#pre-requisites-for-installation-of-the-csi-drivers) for deploying the driver via Dell CSM Operator.
 
 7. Install the CSI driver for your chosen storage platform on the source cluster according to the instructions for [installing the drivers using CSM Operator](../../../csmoperator/drivers/#installing-csi-driver-via-operator).

--- a/content/docs/replication/deployment/install-repctl.md
+++ b/content/docs/replication/deployment/install-repctl.md
@@ -1,11 +1,12 @@
 ---
 title: Installation using repctl
 linktitle: Installation using repctl
-weight: 4 
+weight: 4
 description: Installation of CSM for Replication using repctl
 ---
 
 ## Install Replication Walkthrough
+> **_NOTE:_**  These steps should not be used when installing using Dell CSM Operator.
 
 You can start using Container Storage Modules (CSM) for Replication with help from `repctl` using these simple steps:
 
@@ -14,6 +15,7 @@ You can start using Container Storage Modules (CSM) for Replication with help fr
       ```shell
       ./repctl cluster add -f "/root/.kube/config-1","/root/.kube/config-2" -n "cluster-1","cluster-2"
       ```
+   > **_NOTE:_**  If using a single Kubernetes cluster in a stretched configuration there will be only one cluster.
 3. Install replication controller and CRDs:
       ```shell
       ./repctl create -f ../deploy/replicationcrds.all.yaml
@@ -28,7 +30,7 @@ You can start using Container Storage Modules (CSM) for Replication with help fr
           ```
     2. (Less secure) Inject admin configs into clusters:
           ```shell
-          ./repctl cluster inject 
+          ./repctl cluster inject
           ```
 5. Modify `examples/<storage>_example_values.yaml` config with replication
    information:
@@ -44,4 +46,4 @@ You can start using Container Storage Modules (CSM) for Replication with help fr
       ```
 
 
-> Note: all `repctl` output is saved alongside the `repctl` binary in a `repctl.log` file and can be attached to any installation troubleshooting requests. 
+> Note: all `repctl` output is saved in a `repctl.log` file in the current working directory and can be attached to any installation troubleshooting requests.

--- a/content/docs/replication/deployment/installation.md
+++ b/content/docs/replication/deployment/installation.md
@@ -20,7 +20,7 @@ clusters which will be required during or after the installation.
 You can download a pre-built repctl binary from our [Releases](https://github.com/dell/csm-replication/releases) page.
 Alternately, if you want to build the binary yourself, you can follow these steps:
 ```shell
-git clone github.com/dell/csm-replication
+git clone -b v1.4.0 https://github.com/dell/csm-replication.git
 cd csm-replication/repctl
 make build
 ```
@@ -51,10 +51,10 @@ bash scripts/install.sh --values ./myvalues.yaml
 > The feature can be enabled by modifying `values.yaml`.
 >``` hostAliases:
 > - ip: "10.10.10.10"
->   hostnames: 
+>   hostnames:
 >     - "foo.bar"
 > - ip: "10.10.10.11"
->   hostnames: 
+>   hostnames:
 >     - "foo.baz"
 
 This script will do the following:


### PR DESCRIPTION
# Description
Cleared up confusing documentation for installing Replication via CSM Operator. The current documentation is referring to the Helm repctl section for installation steps and these steps are not compatible with the Operator install process. This change also requires fixes in Operator to handle the stretched cluster case. I will update with the PRs for those changes one I get them.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [788](https://github.com/dell/csm/issues/788)|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

