### PR TITLE
Add User Privileges in installation steps of PowerStore

### DIFF
--- a/content/docs/csidriver/installation/helm/powerstore.md
+++ b/content/docs/csidriver/installation/helm/powerstore.md
@@ -193,6 +193,15 @@ CRDs should be configured during replication prepare stage with repctl as descri
 	             NFSv4 ACls are supported for NFSv4 shares on NFSv4 enabled NAS servers only. POSIX ACLs are not supported and only POSIX mode bits are supported for NFSv3 shares.
     
     Add more blocks similar to above for each PowerStore array if necessary. 
+    ### User Privileges
+    The username specified in `secret.yaml` must be from the authentication providers of PowerStore. The user must have enough privileges to perform the actions. The suggested user role are as follows:
+
+    | User Role             |
+    | --------------------- |
+    | Administrator         |
+    | Storage Administrator |
+    | Storage Operator      |
+
 4. Create the secret by running ```kubectl create secret generic powerstore-config -n csi-powerstore --from-file=config=secret.yaml```
 5. Create storage classes using ones from `samples/storageclass` folder as an example and apply them to the Kubernetes cluster by running `kubectl create -f <path_to_storageclass_file>`
    

--- a/content/docs/csidriver/installation/operator/powerstore.md
+++ b/content/docs/csidriver/installation/operator/powerstore.md
@@ -39,9 +39,17 @@ Kubernetes Operators make it easy to deploy and manage the entire lifecycle of c
         nfsAcls: "0777"                           # (Optional) defines permissions - POSIX mode bits or NFSv4 ACLs, to be set on NFS target mount directory.
                                                   # NFSv4 ACls are supported for NFSv4 shares on NFSv4 enabled NAS servers only. POSIX ACLs are not supported and only POSIX mode bits are supported for NFSv3 shares.
    ```
-   Change the parameters with relevant values for your PowerStore array. 
-
+   Change the parameters with relevant values for your PowerStore array.  
    Add more blocks similar to above for each PowerStore array if necessary.
+   ### User Privileges
+   The username specified in `config.yaml` must be from the authentication providers of PowerStore. The user must have enough privileges to perform the actions. The suggested user role are as follows:
+
+   | User Role             |
+   | --------------------- |
+   | Administrator         |
+   | Storage Administrator |
+   | Storage Operator      |
+
 3. Create Kubernetes secret: 
 
    Create a file called `secret.yaml` in same folder as `config.yaml` with following content


### PR DESCRIPTION
# Description
Added User Privileges section in installation steps of PowerStore. This section describes the minimum privileges required for the user provided in secret.yaml.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/777 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

