### PR TITLE
Updating documentation to support k8s 1.27 for Authorization and Resiliency

### DIFF
--- a/content/docs/authorization/_index.md
+++ b/content/docs/authorization/_index.md
@@ -33,8 +33,8 @@ The following diagram shows a high-level overview of CSM for Authorization with 
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS | Supported Versions |
 |-|-|
-| Kubernetes    | 1.24, 1.25, 1.26 |
-| RHEL          |     7.x, 8.x      |
+| Kubernetes    | 1.25, 1.26, 1.27 |
+| RHEL          |     7.x, 8.x     |
 | CentOS        |     7.8, 7.9     |
 {{</table>}}
 
@@ -43,7 +43,7 @@ The following diagram shows a high-level overview of CSM for Authorization with 
 {{<table "table table-striped table-bordered table-sm">}}
 |               | PowerMax         | PowerFlex | PowerScale |
 |---------------|:----------------:|:-------------------:|:----------------:|
-| Storage Array |PowerMax 2000/8000 <br> PowerMax 2500/8500 <br> 5978.479.479, 5978.711.711, 6079.xxx.xxx, Unisphere 10.0|    3.5.x, 3.6.x    | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3 |
+| Storage Array |PowerMax 2000/8000 <br> PowerMax 2500/8500 <br> 5978.479.479, 5978.711.711, 6079.xxx.xxx, Unisphere 10.0|    3.5.x, 3.6.x    | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3, 9.4 |
 {{</table>}}
 
 ## Supported CSI Drivers

--- a/content/docs/resiliency/_index.md
+++ b/content/docs/resiliency/_index.md
@@ -41,8 +41,8 @@ CSM for Resiliency provides the following capabilities:
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS            | Supported Versions |
 | ----------------- | :----------------: |
-| Kubernetes        | 1.24, 1.25, 1.26   |
-| Red Hat OpenShift |     4.10, 4.11     |
+| Kubernetes        | 1.25, 1.26, 1.27   |
+| Red Hat OpenShift | 4.10, 4.11, 4.12   |
 | RHEL              |     7.x, 8.x       |
 | CentOS            |     7.8, 7.9       |
 {{</table>}}


### PR DESCRIPTION
# Description
Updating documentation to support k8s 1.27 for both Authorization and Resiliency
Updated Authorization Powerscale to support OneFS 9.4
Updated Resiliency to support OS 4.12

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

