### PR TITLE
[bug-985]: Update karavictl CLI 

### DIFF
--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -757,7 +757,7 @@ karavictl storage update [flags]
 ##### Required Flags
 ```
   -e, --endpoint         Endpoint of REST API gateway
-  -a, --array-insecure   Array insecure skip verify
+  -a, --array-insecure   Skip certificate validation of the storage array
   -p, --pass             Password (default "****")
   -s, --system-id        System identifier (default "systemid")
   -t, --type             Type of storage system ("powerflex", "powermax")

--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -70,10 +70,10 @@ storage products from Kubernetes clusters
 ##### Options
 
 ```
-      --config      string   config file (default is $HOME/.karavictl.yaml)
-  -h, --help                 help for karavictl
-  -t, --toggle               Help message for toggle
-  -f, --admin-token string   Specify the admin token file
+  -h, --help                 Help for karavictl
+  -f, --admin-token string   Path to admin token file; required for all commands except `admin token` and `cluster-info`
+      --addr                 Address of the CSM Authorization Proxy-Server; required for all commands except `admin token` and `cluster-info`
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -130,13 +130,6 @@ $ karavictl admin token --name admin --jwt-signing-secret secret --access-token-
 }
 
 ```
-##### Options inherited from parent commands
-
-```
-      --config string   config file (default is $HOME/.karavictl.yaml)
-```
----
-
 
 
 ### karavictl cluster-info
@@ -156,12 +149,6 @@ karavictl cluster-info [flags]
 ```
   -h, --help    help for cluster-info
   -w, --watch   Watch for changes
-```
-
-##### Options inherited from parent commands
-
-```
-      --config string   config file (default is $HOME/.karavictl.yaml)
 ```
 
 ##### Output
@@ -206,8 +193,9 @@ karavictl generate [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -233,7 +221,7 @@ be piped directly to kubectl:
 Example: 
 ```bash 
 
-karavictl generate token --tenant Alice --admin-token admintoken.yaml | kubectl apply -f -
+karavictl generate token --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com | kubectl apply -f -
 ```
 ```bash
 karavictl generate token [flags]
@@ -251,16 +239,15 @@ karavictl generate token [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl generate token --tenant Alice --admin-token admintoken.yaml
+karavictl generate token --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 ```yaml
 apiVersion: v1
@@ -278,7 +265,7 @@ type: Opaque
 Usually, you will want to pipe the output to kubectl to apply the secret
 ```bash
 
-karavictl generate token --tenant Alice --admin-token admintoken.yaml | kubectl apply -f -
+karavictl generate token --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com | kubectl apply -f -
 ```
 
 
@@ -308,8 +295,9 @@ karavictl role [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -343,16 +331,15 @@ karavictl role get [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl role get CSISilver --admin-token admintoken.yaml
+karavictl role get CSISilver --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 ```yaml
 {
@@ -394,16 +381,15 @@ karavictl role list [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl role list --admin-token admintoken.yaml
+karavictl role list --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 ```yaml
 {
@@ -464,16 +450,15 @@ karavictl role create [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl role create --from-file roles.json --admin-token admintoken.yaml
+karavictl role create --from-file roles.json --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the creation occurred.
 
@@ -481,7 +466,7 @@ Alternatively, you can create a role in-line using:
 
 ```bash
 
-karavictl role create --role=role-name=system-type=000000000001=mypool=200000000 --admin-token admintoken.yaml
+karavictl role create --role=role-name=system-type=000000000001=mypool=200000000 --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 
 ---
@@ -511,17 +496,16 @@ karavictl role update [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl role update --from-file roles.json --admin-token admintoken.yaml
+karavictl role update --from-file roles.json --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the update occurred.
 
@@ -556,16 +540,15 @@ karavictl role delete <role-name> [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl role delete CSISilver --admin-token admintoken.yaml
+karavictl role delete CSISilver --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the deletion occurred.
 
@@ -596,8 +579,9 @@ karavictl rolebinding [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -633,17 +617,16 @@ karavictl rolebinding create [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl rolebinding create --role CSISilver --tenant Alice --admin-token admintoken.yaml
+karavictl rolebinding create --role CSISilver --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the rolebinding creation occurred.
 
@@ -675,17 +658,16 @@ karavictl rolebinding delete [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl rolebinding delete --role CSISilver --tenant Alice --admin-token admintoken.yaml
+karavictl rolebinding delete --role CSISilver --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the rolebinding deletion occurred.
 
@@ -710,16 +692,15 @@ karavictl storage [flags]
 ##### Options
 
 ```
-      --addr      string   Address of the server (default "localhost")
   -h, --help               Help for storage
-      --insecure           Skip certificate validation
 ```
 
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -755,17 +736,16 @@ karavictl storage get [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl storage get --type powerflex --system-id 3000000000011111 --admin-token admintoken.yaml
+karavictl storage get --type powerflex --system-id 3000000000011111 --admin-token admintoken.yaml --addr csm-authorization.host.com
 {
   "User": "admin",
   "Password": "(omitted)",
@@ -802,16 +782,15 @@ karavictl storage list [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl storage list --admin-token admintoken.yaml
+karavictl storage list --admin-token admintoken.yaml --addr csm-authorization.host.com
 
 {
   "storage": {
@@ -850,7 +829,7 @@ karavictl storage create [flags]
 ```
   -e, --endpoint string    Endpoint of REST API gateway
   -h, --help               Help for create
-  -a, --array-insecure     Array insecure skip verify
+  -a, --array-insecure     Skip certificate validation of the storage array
   -p, --password string    Password (default "****")
   -s, --system-id string   System identifier (default "systemid")
   -t, --type string        Type of storage system ("powerflex", "powermax")
@@ -860,17 +839,16 @@ karavictl storage create [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl storage create --endpoint https://1.1.1.1 --insecure --array-insecure --system-id 3000000000011111 --type powerflex --user admin --password ******** --admin-token admintoken.yaml
+karavictl storage create --endpoint https://1.1.1.1 --insecure --array-insecure --system-id 3000000000011111 --type powerflex --user admin --password ******** --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl storage get --type <storage-system-type> --system-id <storage-system-id>` to confirm the creation occurred.
 
@@ -906,17 +884,16 @@ karavictl storage update [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl storage update --endpoint https://1.1.1.1 --insecure --array-insecure --system-id 3000000000011111 --type powerflex --user admin --password ******** --admin-token admintoken.yaml
+karavictl storage update --endpoint https://1.1.1.1 --insecure --array-insecure --system-id 3000000000011111 --type powerflex --user admin --password ******** --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl storage get --type <storage-system-type> --system-id <storage-system-id>` to confirm the update occurred.
 
@@ -949,16 +926,15 @@ karavictl storage delete [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   Config file (default is $HOME/.karavictl.yaml)
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 ```bash
 
-karavictl storage delete --type powerflex --system-id 3000000000011111 --admin-token admintoken.yaml
+karavictl storage delete --type powerflex --system-id 3000000000011111 --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl storage get --type <storage-system-type> --system-id <storage-system-id>` to confirm the deletion occurred.
 
@@ -989,8 +965,9 @@ karavictl tenant [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -1026,15 +1003,14 @@ karavictl tenant create [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 ```bash
-karavictl tenant create --name Alice --admin-token admintoken.yaml
+karavictl tenant create --name Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the creation occurred.
 
@@ -1067,16 +1043,15 @@ karavictl tenant get [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --config      string   config file (default is $HOME/.karavictl.yaml)
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl tenant get --name Alice --admin-token admintoken.yaml
+karavictl tenant get --name Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 
 {
   "name": "Alice"
@@ -1112,16 +1087,15 @@ karavictl tenant list [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl tenant list --admin-token admintoken.yaml
+karavictl tenant list --admin-token admintoken.yaml --addr csm-authorization.host.com
 
 {
   "tenants": [
@@ -1162,15 +1136,14 @@ karavictl tenant revoke [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --insecure             Skip certificate validation
-      --config      string   config file (default is $HOME/.karavictl.yaml)
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 ```bash
-karavictl tenant revoke --name Alice --admin-token admintoken.yaml
+karavictl tenant revoke --name Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output.
 
@@ -1202,15 +1175,14 @@ karavictl tenant delete [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --config      string   config file (default is $HOME/.karavictl.yaml)
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 ```bash
-karavictl tenant delete --name Alice --admin-token admintoken.yaml
+karavictl tenant delete --name Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the deletion occurred.
 
@@ -1243,15 +1215,14 @@ karavictl tenant update [flags]
 ##### Options inherited from parent commands
 
 ```
-  -f, --admin-token string   Specify the admin token file
-      --addr        string   Address of the server (default "localhost")
-      --config      string   config file (default is $HOME/.karavictl.yaml)
-      --insecure             Skip certificate validation
+  -f, --admin-token string   Path to admin token file; required
+      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 ```bash
 
-karavictl tenant update --name Alice --approvesdc=false --admin-token admintoken.yaml
+karavictl tenant update --name Alice --approvesdc=false --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the update was persisted.

--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -72,7 +72,7 @@ storage products from Kubernetes clusters
 ```
   -h, --help                 Help for karavictl
   -f, --admin-token string   Path to admin token file; required for all commands except `admin token` and `cluster-info`
-      --addr                 Address of the CSM Authorization Proxy-Server; required for all commands except `admin token` and `cluster-info`
+      --addr                 Address of the CSM Authorization Proxy Server; required for all commands except `admin token` and `cluster-info`
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -194,7 +194,7 @@ karavictl generate [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -240,7 +240,7 @@ karavictl generate token [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -296,7 +296,7 @@ karavictl role [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -332,7 +332,7 @@ karavictl role get [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -382,7 +382,7 @@ karavictl role list [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -451,7 +451,7 @@ karavictl role create [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -497,7 +497,7 @@ karavictl role update [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -541,7 +541,7 @@ karavictl role delete <role-name> [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -580,7 +580,7 @@ karavictl rolebinding [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -618,7 +618,7 @@ karavictl rolebinding create [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -659,7 +659,7 @@ karavictl rolebinding delete [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -699,7 +699,7 @@ karavictl storage [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -737,7 +737,7 @@ karavictl storage get [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -783,7 +783,7 @@ karavictl storage list [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -840,7 +840,7 @@ karavictl storage create [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -885,7 +885,7 @@ karavictl storage update [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -927,7 +927,7 @@ karavictl storage delete [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -966,7 +966,7 @@ karavictl tenant [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -1004,7 +1004,7 @@ karavictl tenant create [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -1044,7 +1044,7 @@ karavictl tenant get [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -1088,7 +1088,7 @@ karavictl tenant list [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -1137,7 +1137,7 @@ karavictl tenant revoke [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -1176,7 +1176,7 @@ karavictl tenant delete [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
@@ -1216,7 +1216,7 @@ karavictl tenant update [flags]
 
 ```
   -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy-Server; required
+      --addr                 Address of the CSM Authorization Proxy Server; required
       --insecure             Skip certificate validation of the CSM Authorization Proxy Server
 ```
 

--- a/content/docs/authorization/cli.md
+++ b/content/docs/authorization/cli.md
@@ -97,14 +97,17 @@ The tokens output in YAML format, which can be saved in a file.
 karavictl admin token [flags]
 ```
 
-##### Options
+##### Required Flags
 ```
-  -h, --help                                 help for token
-  -s, --jwt-signing-secret        string     Specify JWT signing secret, or omit to use stdin
-  -n, --name                      string     Administration name
-      --refresh-token-expiration  duration   Expiration time of the refresh token, e.g. 48h (default 720h0m0s)
-      --access-token-expiration   duration   Expiration time of the access token, e.g. 1m30s (default 1m0s)
+  -n, --name   Name of the tenant
+```
 
+##### Optional Flags
+```
+  -h, --help                       Help for token
+  -s, --jwt-signing-secret         Specify JWT signing secret, or omit to use stdin
+      --refresh-token-expiration   Expiration time of the refresh token, e.g. 48h (default 720h0m0s)
+      --access-token-expiration    Expiration time of the access token, e.g. 1m30s (default 1m0s)
 ```
 
 ##### Output
@@ -144,10 +147,9 @@ Prints table of resources within the cluster, including their readiness
 karavictl cluster-info [flags]
 ```
 
-##### Options
-
+##### Optional Flags
 ```
-  -h, --help    help for cluster-info
+  -h, --help    Help for cluster-info
   -w, --watch   Watch for changes
 ```
 
@@ -184,29 +186,11 @@ Generates resources for use with CSM
 karavictl generate [flags]
 ```
 
-##### Options
+##### Optional Flags
 
 ```
-  -h, --help   help for generate
+  -h, --help   Help for generate
 ```
-
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
-```
-
-##### Output
-
-Outputs help text
-
-
-
----
-
-
 
 ### karavictl generate token
 
@@ -220,28 +204,22 @@ be piped directly to kubectl:
 
 Example: 
 ```bash 
-
 karavictl generate token --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com | kubectl apply -f -
 ```
-```bash
-karavictl generate token [flags]
+
+##### Required Flags
+```
+  -t, --tenant        Name of the tenant
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options
-
+##### Optional Flags
 ```
-  -h, --help                              help for token
-  -t, --tenant                 string     Tenant name
-   --access-token-expiration   duration   Expiration time of the access token, e.g. 1m30s (default 1m0s)
-   --refresh-token-expiration  duration   Expiration time of the refresh token, e.g. 48h (default 720h0m0s)
-```
-
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help                       Help for token
+      --insecure                   Skip certificate validation of the CSM Authorization Proxy Server
+      --access-token-expiration    Expiration time of the access token, e.g. 1m30s (default 1m0s)
+      --refresh-token-expiration   Expiration time of the refresh token, e.g. 48h (default 720h0m0s)
 ```
 
 ##### Output
@@ -264,15 +242,8 @@ type: Opaque
 
 Usually, you will want to pipe the output to kubectl to apply the secret
 ```bash
-
 karavictl generate token --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com | kubectl apply -f -
 ```
-
-
-
-## Role Commands
-
-
 
 ### karavictl role
 
@@ -292,24 +263,6 @@ karavictl role [flags]
   -h, --help   Help for role
 ```
 
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
-```
-
-##### Output
-
-Outputs help text
-
-
-
----
-
-
-
 ### karavictl role get 
 
 Get role
@@ -322,18 +275,17 @@ Get role
 karavictl role get [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   help for get
+  -n, --name          Name of the role
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for get
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -372,18 +324,16 @@ List roles
 karavictl role list [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   Help for list
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for list
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -436,38 +386,29 @@ Creates one or more CSM roles
 karavictl role create [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -f, --from-file string   Role data from a file
-      --role      strings  Role in the form <name>=<type>=<id>=<pool>=<quota>
-  -h, --help               Help for create
+      --role          Role in the form <name>=<type>=<id>=<pool>=<quota>
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
+```
+
+##### Optional Flags
+```
+  -h, --help       Help for create
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 *NOTE:* 
-  - For PowerScale, set the `quota` to 0 as CSM for Authorization does not enforce quota limits.
+  - Setting the `quota` to 0 will not enforce storage quota
 
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
-```
 
 ##### Output
 
 ```bash
-karavictl role create --from-file roles.json --admin-token admintoken.yaml --addr csm-authorization.host.com
-```
-On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the creation occurred.
-
-Alternatively, you can create a role in-line using:
-
-```bash
-
 karavictl role create --role=role-name=system-type=000000000001=mypool=200000000 --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
+On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the creation occurred.
 
 ---
 
@@ -485,36 +426,27 @@ Updates the quota of one or more CSM roles
 karavictl role update [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -f, --from-file string   Role data from a file
-      --role      strings  Role in the form <name>=<type>=<id>=<pool>=<quota>
-  -h, --help               Help for update
+      --role          Role in the form <name>=<type>=<id>=<pool>=<quota>
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for update
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
 
-karavictl role update --from-file roles.json --admin-token admintoken.yaml --addr csm-authorization.host.com
+karavictl role update --role=role-name=system-type=000000000001=mypool=400000000 --admin-token admintoken.yaml
 ```
 On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the update occurred.
 
-Alternatively, you can update existing roles in-line using:
-
-```bash
-
-karavictl role update --role=role-name=system-type=000000000001=mypool=400000000 --admin-token admintoken.yaml
-```
 ---
 
 
@@ -528,27 +460,26 @@ Delete role
 Delete role
 
 ```bash
-karavictl role delete <role-name> [flags]
+karavictl role delete [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   Help for delete
+      --role          Role in the form <name>=<type>=<id>=<pool>=<quota>
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
 
 ```bash
-karavictl role delete CSISilver --admin-token admintoken.yaml --addr csm-authorization.host.com
+karavictl role delete --name CSISilver --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
 On success, there will be no output. You may run `karavictl role get <role-name>` to confirm the deletion occurred.
 
@@ -576,24 +507,6 @@ karavictl rolebinding [flags]
   -h, --help   help for rolebinding
 ```
 
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
-```
-
-##### Output
-
-Outputs help text
-
-
-
----
-
-
-
 ### karavictl rolebinding create
 
 Create a rolebinding between role and tenant
@@ -606,20 +519,18 @@ Creates a rolebinding between role and tenant
 karavictl rolebinding create [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   help for create
-  -r, --role string       Role name
-  -t, --tenant string     Tenant name
+  -r, --role          Role name
+  -t, --tenant        Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for create
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -647,20 +558,18 @@ Deletes a rolebinding between role and tenant
 karavictl rolebinding delete [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   help for delete
-  -r, --role string      Role name
-  -t, --tenant string    Tenant name
+  -r, --role          Role name
+  -t, --tenant        Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -669,7 +578,7 @@ karavictl rolebinding delete [flags]
 
 karavictl rolebinding delete --role CSISilver --tenant Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
-On success, there will be no output. You may run `karavictl tenant get --name <tenant-name>` to confirm the rolebinding deletion occurred.
+On success, there will be no output.
 
 
 
@@ -695,24 +604,6 @@ karavictl storage [flags]
   -h, --help               Help for storage
 ```
 
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
-```
-
-##### Output
-
-Outputs help text
-
-
-
----
-
-
-
 ### karavictl storage get
 
 Get details on a registered storage system.
@@ -725,20 +616,18 @@ Gets details on a registered storage system.
 karavictl storage get [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help               Help for get
-  -s, --system-id string   System identifier (default "systemid")
-  -t, --type string        Type of storage system ("powerflex", "powermax")
+  -s, --system-id     System identifier (default "systemid")
+  -t, --type          Type of storage system ("powerflex", "powermax", "powerscale")
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -772,19 +661,17 @@ Lists registered storage systems.
 karavictl storage list [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help          Help for list
-  -t, --type string   Type of storage system
+  -t, --type          Type of storage system ("powerflex", "powermax", "powerscale")
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -824,24 +711,22 @@ Creates and registers a storage system.
 karavictl storage create [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -e, --endpoint string    Endpoint of REST API gateway
-  -h, --help               Help for create
-  -a, --array-insecure     Skip certificate validation of the storage array
-  -p, --password string    Password (default "****")
-  -s, --system-id string   System identifier (default "systemid")
-  -t, --type string        Type of storage system ("powerflex", "powermax")
-  -u, --user string        Username (default "admin")
+  -e, --endpoint         Endpoint of REST API gateway
+  -a, --array-insecure   Skip certificate validation of the storage array
+  -p, --password         Password (default "****")
+  -s, --system-id        System identifier (default "systemid")
+  -t, --type             Type of storage system ("powerflex", "powermax")
+  -u, --user             Username (default "admin")
+  -f, --admin-token      Path to admin token file
+      --addr             Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -869,24 +754,22 @@ Updates a registered storage system.
 karavictl storage update [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -e, --endpoint string    Endpoint of REST API gateway
-  -h, --help               Help for update
-  -a, --array-insecure     Array insecure skip verify
-  -p, --pass string        Password (default "****")
-  -s, --system-id string   System identifier (default "systemid")
-  -t, --type string        Type of storage system ("powerflex", "powermax")
-  -u, --user string        Username (default "admin")
+  -e, --endpoint         Endpoint of REST API gateway
+  -a, --array-insecure   Array insecure skip verify
+  -p, --pass             Password (default "****")
+  -s, --system-id        System identifier (default "systemid")
+  -t, --type             Type of storage system ("powerflex", "powermax")
+  -u, --user             Username (default "admin")
+  -f, --admin-token      Path to admin token file
+      --addr             Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -915,20 +798,18 @@ Deletes a registered storage system.
 karavictl storage delete [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help               Help for delete
-  -s, --system-id string   System identifier (default "systemid")
-  -t, --type      string   Type of storage system ("powerflex", "powermax")
+  -s, --system-id     System identifier (default "systemid")
+  -t, --type          Type of storage system ("powerflex", "powermax")
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -962,19 +843,6 @@ karavictl tenant [flags]
   -h, --help   help for tenant
 ```
 
-##### Options inherited from parent commands
-
-```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
-```
-
-##### Output
-
-Outputs help text
-
-
 
 ---
 
@@ -992,20 +860,18 @@ Creates a tenant resource within CSM
 karavictl tenant create [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
+  -n, --name          Tenant name
   -a, --approvesdc    To allow/deny SDC approval requests (default true | This flag is only applicable to PowerFlex. This flag will Approve/Deny a tenant's SDC request)
-  -h, --help   help for create
-  -n, --name string   Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -1033,19 +899,17 @@ Gets a tenant resource and its assigned roles within CSM
 karavictl tenant get [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help          help for get
-  -n, --name string   Tenant name
+  -n, --name          Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -1078,18 +942,16 @@ Lists tenant resources within CSM
 karavictl tenant list [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   help for list
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -1125,20 +987,18 @@ Revokes access to storage resources for a tenant
 karavictl tenant revoke [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -c, --cancel        Cancel a previous tenant revocation
-  -h, --help   help for create
-  -n, --name string   Tenant name
+  -n, --name          Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -c, --cancel     Cancel a previous tenant revocation
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -1165,19 +1025,17 @@ Deletes a tenant resource within CSM
 karavictl tenant delete [flags]
 ```
 
-##### Options
-
+##### Required Flags
 ```
-  -h, --help   help for delete
-  -n, --name string   Tenant name
+  -n, --name          Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output
@@ -1204,20 +1062,18 @@ Updates a tenant resource within CSM
 karavictl tenant update [flags]
 ```
 
-#### Options
-
+##### Required Flags
 ```
+  -n, --name          Tenant name
   -a, --approvesdc    To allow/deny SDC approval requests (default true | This flag is only applicable to PowerFlex. This flag will Approve/Deny a tenant's SDC request)
-  -h, --help   help for update
-  -n, --name string   Tenant name
+  -f, --admin-token   Path to admin token file
+      --addr          Address of the CSM Authorization Proxy Server
 ```
 
-##### Options inherited from parent commands
-
+##### Optional Flags
 ```
-  -f, --admin-token string   Path to admin token file; required
-      --addr                 Address of the CSM Authorization Proxy Server; required
-      --insecure             Skip certificate validation of the CSM Authorization Proxy Server
+  -h, --help       Help for delete
+      --insecure   Skip certificate validation of the CSM Authorization Proxy Server
 ```
 
 ##### Output


### PR DESCRIPTION
# Description

- Removes `config` flag which isn't used
- Updates examples with `addr` flag
- Updates to say that `admin-token` and `addr` flag are required for relevant commands

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/895|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

