### PR TITLE
Volume limits support for CSI Powerstore

### DIFF
--- a/content/docs/csidriver/features/powerstore.md
+++ b/content/docs/csidriver/features/powerstore.md
@@ -434,7 +434,7 @@ The user can set the volume limit for a node by creating a node label `max-power
 
 The user can also set the volume limit for all the nodes in the cluster by specifying the same to `maxPowerstoreVolumesPerNode` attribute in values.yaml.
 
->**NOTE:** <br>The default value of `maxPowerstoreVolumesPerNode` is 0. <br>If `maxPowerstoreVolumesPerNode` is set to zero, then CO shall decide how many volumes of this type can be published by the controller to the node.<br><br>The volume limit specified to `maxPowerstoreVolumesPerNode` attribute is applicable to all the nodes in the cluster for which node label `max-powerstore-volumes-per-node` is not set.
+>**NOTE:** <br>The default value of `maxPowerstoreVolumesPerNode` is 0. <br>If `maxPowerstoreVolumesPerNode` is set to zero, then CO shall decide how many volumes of this type can be published by the controller to the node.<br><br>The volume limit specified in `maxPowerstoreVolumesPerNode` attribute is applicable to all the nodes in the cluster for which the node label `max-powerstore-volumes-per-node` is not set.
 
 ## Reuse PowerStore hostname 
 

--- a/content/docs/csidriver/features/powerstore.md
+++ b/content/docs/csidriver/features/powerstore.md
@@ -425,6 +425,16 @@ kubectl get nodes --show-labels
 
 For any additional information about the topology, see the [Kubernetes Topology documentation](https://kubernetes-csi.github.io/docs/topology.html).
 
+## Volume Limit
+
+The CSI Driver for Dell PowerStore allows users to specify the maximum number of PowerStore volumes that can be used in a node.
+
+The user can set the volume limit for a node by creating a node label `max-powerstore-volumes-per-node` and specifying the volume limit for that node.
+<br/> `kubectl label node <node_name> max-powerstore-volumes-per-node=<volume_limit>`
+
+The user can also set the volume limit for all the nodes in the cluster by specifying the same to `maxPowerstoreVolumesPerNode` attribute in values.yaml.
+
+>**NOTE:** <br>The default value of `maxPowerstoreVolumesPerNode` is 0. <br>If `maxPowerstoreVolumesPerNode` is set to zero, then CO shall decide how many volumes of this type can be published by the controller to the node.<br><br>The volume limit specified to `maxPowerstoreVolumesPerNode` attribute is applicable to all the nodes in the cluster for which node label `max-powerstore-volumes-per-node` is not set.
 
 ## Reuse PowerStore hostname 
 

--- a/content/docs/csidriver/features/powerstore.md
+++ b/content/docs/csidriver/features/powerstore.md
@@ -434,7 +434,7 @@ The user can set the volume limit for a node by creating a node label `max-power
 
 The user can also set the volume limit for all the nodes in the cluster by specifying the same to `maxPowerstoreVolumesPerNode` attribute in values.yaml.
 
->**NOTE:** <br>The default value of `maxPowerstoreVolumesPerNode` is 0. <br>If `maxPowerstoreVolumesPerNode` is set to zero, then CO shall decide how many volumes of this type can be published by the controller to the node.<br><br>The volume limit specified in `maxPowerstoreVolumesPerNode` attribute is applicable to all the nodes in the cluster for which the node label `max-powerstore-volumes-per-node` is not set.
+>**NOTE:** <br>The default value of `maxPowerstoreVolumesPerNode` is 0. <br>If `maxPowerstoreVolumesPerNode` is set to zero, then CO shall decide how many volumes of this type can be published by the controller to the node.<br><br>The volume limit specified in the `maxPowerstoreVolumesPerNode` attribute is applicable to all the nodes in the cluster for which the node label `max-powerstore-volumes-per-node` is not set.
 
 ## Reuse PowerStore hostname 
 

--- a/content/docs/csidriver/installation/helm/powerstore.md
+++ b/content/docs/csidriver/installation/helm/powerstore.md
@@ -184,7 +184,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
 | logFormat | Defines CSI driver log format | No | "JSON" |
 | externalAccess | Defines additional entries for hostAccess of NFS volumes, single IP address and subnet are valid entries | No | " " |
 | kubeletConfigDir | Defines kubelet config path for cluster | Yes | "/var/lib/kubelet" |
-| maxPowerstoreVolumesPerNode | Defines the default value for maximum number of volumes that the controller can publish to the node. If the value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
+| maxPowerstoreVolumesPerNode | Defines the default value for maximum number of volumes that the controller can publish to the node. If the value is zero, then CO SHALL decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which the node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
 | imagePullPolicy | Policy to determine if the image should be pulled prior to starting the container. | Yes | "IfNotPresent" |
 | nfsAcls | Defines permissions - POSIX mode bits or NFSv4 ACLs, to be set on NFS target mount directory. | No | "0777" |
 | connection.enableCHAP   | Defines whether the driver should use CHAP for iSCSI connections or not | No | False |

--- a/content/docs/csidriver/installation/helm/powerstore.md
+++ b/content/docs/csidriver/installation/helm/powerstore.md
@@ -184,7 +184,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
 | logFormat | Defines CSI driver log format | No | "JSON" |
 | externalAccess | Defines additional entries for hostAccess of NFS volumes, single IP address and subnet are valid entries | No | " " |
 | kubeletConfigDir | Defines kubelet config path for cluster | Yes | "/var/lib/kubelet" |
-| maxPowerstoreVolumesPerNode | Defines the default value for maximum number of volumes that the controller can publish to the node. If the value is zero, then CO SHALL decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which the node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
+| maxPowerstoreVolumesPerNode | Defines the default value for maximum number of volumes that the controller can publish to the node. If the value is zero, then CO shall decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which the node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
 | imagePullPolicy | Policy to determine if the image should be pulled prior to starting the container. | Yes | "IfNotPresent" |
 | nfsAcls | Defines permissions - POSIX mode bits or NFSv4 ACLs, to be set on NFS target mount directory. | No | "0777" |
 | connection.enableCHAP   | Defines whether the driver should use CHAP for iSCSI connections or not | No | False |

--- a/content/docs/csidriver/installation/helm/powerstore.md
+++ b/content/docs/csidriver/installation/helm/powerstore.md
@@ -184,7 +184,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
 | logFormat | Defines CSI driver log format | No | "JSON" |
 | externalAccess | Defines additional entries for hostAccess of NFS volumes, single IP address and subnet are valid entries | No | " " |
 | kubeletConfigDir | Defines kubelet config path for cluster | Yes | "/var/lib/kubelet" |
-| maxPowerstoreVolumesPerNode | Defines the default value for a maximum number of volumes that the controller can publish to the node. If the value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
+| maxPowerstoreVolumesPerNode | Defines the default value for maximum number of volumes that the controller can publish to the node. If the value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
 | imagePullPolicy | Policy to determine if the image should be pulled prior to starting the container. | Yes | "IfNotPresent" |
 | nfsAcls | Defines permissions - POSIX mode bits or NFSv4 ACLs, to be set on NFS target mount directory. | No | "0777" |
 | connection.enableCHAP   | Defines whether the driver should use CHAP for iSCSI connections or not | No | False |

--- a/content/docs/csidriver/installation/helm/powerstore.md
+++ b/content/docs/csidriver/installation/helm/powerstore.md
@@ -184,6 +184,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
 | logFormat | Defines CSI driver log format | No | "JSON" |
 | externalAccess | Defines additional entries for hostAccess of NFS volumes, single IP address and subnet are valid entries | No | " " |
 | kubeletConfigDir | Defines kubelet config path for cluster | Yes | "/var/lib/kubelet" |
+| maxPowerstoreVolumesPerNode | Defines the default value for a maximum number of volumes that the controller can publish to the node. If the value is zero CO SHALL decide how many volumes of this type can be published by the controller to the node. This limit is applicable to all the nodes in the cluster for which node label 'max-powerstore-volumes-per-node' is not set. | No | 0 |
 | imagePullPolicy | Policy to determine if the image should be pulled prior to starting the container. | Yes | "IfNotPresent" |
 | nfsAcls | Defines permissions - POSIX mode bits or NFSv4 ACLs, to be set on NFS target mount directory. | No | "0777" |
 | connection.enableCHAP   | Defines whether the driver should use CHAP for iSCSI connections or not | No | False |

--- a/content/docs/csidriver/installation/operator/powerstore.md
+++ b/content/docs/csidriver/installation/operator/powerstore.md
@@ -150,6 +150,7 @@ data:
 | X_CSI_NFS_ACLS | Defines permissions - POSIX mode bits or NFSv4 ACLs, to be set on NFS target mount directory. | No | "0777" |
 | ***Node parameters*** |
 | X_CSI_POWERSTORE_ENABLE_CHAP | Set to true if you want to enable iSCSI CHAP feature | No | false |
+| X_CSI_POWERSTORE_MAX_VOLUMES_PER_NODE | Specify the default value for the maximum number of volumes that the controller can publish to the node | No | 0 |
 
 6.  Execute the following command to create PowerStore custom resource:`kubectl create -f <input_sample_file.yaml>`. The above command will deploy the CSI-PowerStore driver.
       - After that the driver should be installed, you can check the condition of driver pods by running `kubectl get all -n <driver-namespace>`


### PR DESCRIPTION
# Description
Support for volume limits feature in CSI Powerstore driver. The feature can be used either by setting :

- maxPowerstoreVolumesPerNode in values.yaml
- setting node label "max-powerstore-volumes-per-node"

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/876|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

