### PR TITLE
[feature-885]: Include isDefault field for every array for csi-unity

### DIFF
--- a/content/docs/csidriver/installation/helm/unity.md
+++ b/content/docs/csidriver/installation/helm/unity.md
@@ -210,6 +210,7 @@ Procedure
         password: "password"
         endpoint: "https://10.1.1.2/"
         skipCertificateValidation: true
+        isDefault: false
     ```
 
 	Use the following command to create a new secret unity-creds from `secret.yaml` file.
@@ -245,6 +246,7 @@ Procedure
       password: "password"
       endpoint: "https://10.1.1.2/"
       skipCertificateValidation: true
+      isDefault: false
     ```
     
     **Note:** Parameters "allowRWOMultiPodAccess" and "syncNodeInfoInterval" have been enabled for configuration in values.yaml and this helps users to dynamically change these values without the need for driver re-installation.


### PR DESCRIPTION
# Description

`isDefault` should be included in every sample secret for csi-unity since it is a required field.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/885|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

