### PR TITLE
Wizard cleanup images

### DIFF
--- a/content/docs/deployment/csminstallationwizard/src/csm-versions/default-values.properties
+++ b/content/docs/deployment/csminstallationwizard/src/csm-versions/default-values.properties
@@ -1,5 +1,4 @@
 csmVersion=1.8.0
-imageRepository=dellemc
 controllerCount=1
 nodeSelectorLabel=node-role.kubernetes.io/control-plane:
 taint=node-role.kubernetes.io/control-plane

--- a/content/docs/deployment/csminstallationwizard/src/index.html
+++ b/content/docs/deployment/csminstallationwizard/src/index.html
@@ -68,18 +68,6 @@
 
                 <!-- main content starts -->
                 <div id="main">
-                  <div class="was-validated row mb-4 image-repository">
-                    <label for="image-repository" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Specify the registry from where the image should be pulled" style="width: 150px;">Image Repository</label>
-                    <div class="col-sm-9"></div>
-                    <div class="col-sm-3">
-                      <input class="form-control input-lg" type="text" id="image-repository" placeholder="dellemc"  oninput="validateInput(validateForm, CONSTANTS)" required>
-                    </div>
-                    <div class="col-sm-4">
-                      <div class="row mt-1">
-                        <a class="reset" id="reset-image-repository" onclick="resetImageRepository(csmMap)">Reset to default</a>
-                      </div>
-                    </div>
-                  </div>
                   <div class="was-validated row mb-4">
                     <label for="csm-version" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Refers to the CSM version" style="width: 115px;">CSM Version</label>
                     <div class="col-sm-9"></div>

--- a/content/docs/deployment/csminstallationwizard/src/static/js/generate-yaml.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/generate-yaml.js
@@ -42,7 +42,6 @@ function setValues(csmMapValues, CONSTANTS_PARAM) {
 	var DriverValues = new Object();
 	DriverValues.csmVersion = document.getElementById("csm-version").value
 	DriverValues.driverVersion = csmMapValues.get("driverVersion");
-	DriverValues.imageRepository = document.getElementById("image-repository").value;
 	DriverValues.monitor = $("#monitor").prop('checked') ? true : false;
 	DriverValues.certSecretCount = document.getElementById("cert-secret-count").value;
 	DriverValues.maxVolumesPerNode = document.getElementById("max-volumes-per-node").value;
@@ -129,7 +128,6 @@ function setValues(csmMapValues, CONSTANTS_PARAM) {
 }
 
 function createYamlString(yamlTpl, yamlTplValues, driverParam, CONSTANTS_PARAM) {
-	yamlTpl = yamlTpl.replaceAll("$IMAGE_REPOSITORY", yamlTplValues.imageRepository);
 	yamlTpl = yamlTpl.replaceAll("$MAX_VOLUMES_PER_NODE", yamlTplValues.maxVolumesPerNode);
 	yamlTpl = yamlTpl.replaceAll("$CONTROLLER_COUNT", yamlTplValues.controllerCount);
 	yamlTpl = yamlTpl.replaceAll("$VOLUME_NAME_PREFIX", yamlTplValues.volNamePrefix);

--- a/content/docs/deployment/csminstallationwizard/src/static/js/ui-functions.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/ui-functions.js
@@ -233,10 +233,6 @@ const onCopyButtonClickHandler = () => {
 const onCopyButtonClick = () => $("#copy").on('click', onCopyButtonClickHandler);
 
 //Reset to default values
-const resetImageRepository = csmMapValue => {
-	document.getElementById("image-repository").value = csmMapValue.get("imageRepository");
-}
-
 const resetControllerCount = csmMapValue => {
 	document.getElementById("controller-count").value = String(csmMapValue.get("controllerCount"));
 }
@@ -321,7 +317,6 @@ function displayModules(installationType, driverName, CONSTANTS_PARAM) {
 	$(".vol-name-prefix").show();
 	$("div#snap-prefix").show();
 	$(".fsGroupPolicy").hide();
-	$(".image-repository").show();
 	$(".resizer").show();
 	$(".snapshot-feature").show();
 	$(".resiliency-operator").hide();
@@ -350,7 +345,6 @@ function displayModules(installationType, driverName, CONSTANTS_PARAM) {
 				$(".resiliency-operator").show();
 				$(".observability").hide();
 				$(".replication-mod").hide();
-				$(".image-repository").hide();
 				$(".cert-manager").hide();
 				$(".vgsnapshot").hide();
 				$(".resizer").hide();
@@ -374,7 +368,6 @@ function displayModules(installationType, driverName, CONSTANTS_PARAM) {
 				$(".replication-operator").show();
 				$(".resiliency").hide();
 				$(".resiliency-operator").show();
-				$(".image-repository").hide();
 				$(".cert-manager").hide();
 				$(".resizer").hide();
 				$(".snapshot-feature").hide();
@@ -401,7 +394,6 @@ function displayModules(installationType, driverName, CONSTANTS_PARAM) {
 				$(".observability-operator").show();
 				$(".observability").hide();
 				$(".replication-operator-clusterid").hide();
-				$(".image-repository").hide();
 				$(".cert-manager").hide();
 				$(".storageArrays").hide();
 				$(".managedArrays").show();
@@ -526,7 +518,6 @@ if (typeof exports !== 'undefined') {
 		onVSphereChange,
 		onNodeSelectorChange,
 		onCopyButtonClickHandler,
-		resetImageRepository,
 		resetMaxVolumesPerNode,
 		resetControllerCount,
 		resetNodeSelectorLabel,

--- a/content/docs/deployment/csminstallationwizard/src/static/js/utility.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/utility.js
@@ -25,9 +25,6 @@ function validateForm(CONSTANTS_PARAM) {
 	if (document.getElementById('installation-type').value.trim() === "") {
 		return false
 	}
-	if (document.getElementById('image-repository').value.trim() === "") {
-		return false
-	}
 	if (document.getElementById('csm-version').value.trim() === "") {
 		return false;
 	}
@@ -112,7 +109,6 @@ function loadDefaultValues() {
 
 function setDefaultValues(defaultValuesParam, csmMapValues) {
 	setMap(defaultValuesParam);
-	document.getElementById("image-repository").value = csmMapValues.get("imageRepository");
 	document.getElementById("csm-version").value = String(csmMapValues.get("csmVersion"));
 	document.getElementById("max-volumes-per-node").value = String(csmMapValues.get("maxVolumesPerNode"));
 	document.getElementById("controller-count").value = String(csmMapValues.get("controllerCount"));

--- a/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.7.0-values.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.7.0-values.template
@@ -5,8 +5,6 @@
 csi-powerstore:
   enabled: $POWERSTORE_ENABLED
   version: v2.7.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
   ## Controller ATTRIBUTES
   controller:
     controllerCount: $CONTROLLER_COUNT
@@ -102,8 +100,6 @@ csi-powermax:
           - endpoint: $POWERMAX_MANAGEMENT_SERVERS_ENDPOINT_URL
           - endpoint: $TARGET_UNISPHERE
   version: v2.7.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
   clusterPrefix: $POWERMAX_CLUSTER_PREFIX
   portGroups: "$POWERMAX_PORT_GROUPS"
   controller:
@@ -160,7 +156,6 @@ csi-vxflexos:
   enabled: $POWERFLEX_ENABLED
   version: v2.7.0
   images:
-    driverRepository: $IMAGE_REPOSITORY
     powerflexSdc: dellemc/sdc:3.6.0.6
   certSecretCount: $CERT_SECRET_COUNT
   controller:
@@ -238,8 +233,7 @@ csi-vxflexos:
 csi-isilon:
   enabled: $POWERSCALE_ENABLED
   version: "v2.7.0"
-  images:
-    driverRepository: $IMAGE_REPOSITORY
+
   certSecretCount: $CERT_SECRET_COUNT
 
   allowedNetworks: []
@@ -349,8 +343,6 @@ csi-isilon:
 csi-unity:
   enabled: $UNITY_ENABLED
   version: v2.7.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
   certSecretCount: $CERT_SECRET_COUNT
   fsGroupPolicy: $FSGROUP_POLICY
   controller:

--- a/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.8.0-values.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.8.0-values.template
@@ -5,8 +5,6 @@
 csi-powerstore:
   enabled: $POWERSTORE_ENABLED
   version: v2.8.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
   ## Controller ATTRIBUTES
   controller:
     controllerCount: $CONTROLLER_COUNT
@@ -17,11 +15,8 @@ csi-powerstore:
     tolerations: $CONTROLLER_TOLERATIONS
     replication:
       enabled: $REPLICATION_ENABLED
-      image: dellemc/dell-csi-replicator:v1.5.0
     vgsnapshot:
       enabled: $VG_SNAPSHOT_ENABLED
-      image: dellemc/csi-volumegroup-snapshotter:v1.2.0
-    metadataretriever: dellemc/csi-metadata-retriever:v1.5.0
     snapshot:
       enabled: $SNAPSHOT_ENABLED
       snapNamePrefix: $SNAP_NAME_PREFIX
@@ -62,30 +57,6 @@ csi-powerstore:
     enabled: $STORAGE_CAPACITY_ENABLED
   podmon:
     enabled: $RESILIENCY_ENABLED
-    image: dellemc/podmon:v1.7.0
-    controller:
-      args:
-        - "--csisock=unix:/var/run/csi/csi.sock"
-        - "--labelvalue=csi-powerstore"
-        - "--arrayConnectivityPollRate=60"
-        - "--driverPath=csi-powerstore.dellemc.com"
-        - "--mode=controller"
-        - "--skipArrayConnectionValidation=false"
-        - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
-
-    node:
-      args:
-        - "--csisock=unix:/var/lib/kubelet/plugins/csi-powerstore.dellemc.com/csi_sock"
-        - "--labelvalue=csi-powerstore"
-        - "--arrayConnectivityPollRate=60"
-        - "--driverPath=csi-powerstore.dellemc.com"
-        - "--mode=node"
-        - "--leaderelection=false"
-        - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
 
   maxPowerstoreVolumesPerNode: $MAX_VOLUMES_PER_NODE
 
@@ -104,8 +75,6 @@ csi-powermax:
       - endpoint: $POWERMAX_MANAGEMENT_SERVERS_ENDPOINT_URL
       - endpoint: $TARGET_UNISPHERE
   version: v2.8.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
   clusterPrefix: $POWERMAX_CLUSTER_PREFIX
   portGroups: "$POWERMAX_PORT_GROUPS"
   controller:
@@ -135,18 +104,13 @@ csi-powermax:
        operator: "Exists"
        effect: "NoExecute"
   csireverseproxy:
-    image: dellemc/csipowermax-reverseproxy:v2.6.0
     deployAsSidecar: true
   replication:
     enabled: $REPLICATION_ENABLED
-    image: dellemc/dell-csi-replicator:v1.5.0
   migration:
     enabled: $MIGRATION_ENABLED
-    image: dellemc/dell-csi-migrator:v1.1.1
-    nodeRescanSidecarImage: dellemc/dell-csi-node-rescanner:v1.0.1
   authorization:
     enabled: $AUTHORIZATION_ENABLED
-    sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
     proxyHost: $AUTHORIZATION_PROXY_HOST
     skipCertificateValidation: $AUTHORIZATION_SKIP_CERTIFICATE_VALIDATION
   storageCapacity:
@@ -163,14 +127,10 @@ csi-powermax:
 csi-vxflexos:
   enabled: $POWERFLEX_ENABLED
   version: v2.8.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
-    powerflexSdc: dellemc/sdc:3.6.1
   certSecretCount: $CERT_SECRET_COUNT
   controller:
     replication:
       enabled: $REPLICATION_ENABLED
-      image: dellemc/dell-csi-replicator:v1.5.0
     healthMonitor:
       enabled: $HEALTH_MONITOR_ENABLED
     controllerCount: $CONTROLLER_COUNT
@@ -211,31 +171,10 @@ csi-vxflexos:
     enabled: $MONITOR_ENABLED
   vgsnapshotter:
     enabled: $VG_SNAPSHOT_ENABLED
-    image: dellemc/csi-volumegroup-snapshotter:v1.2.0
   podmon:
     enabled: $RESILIENCY_ENABLED
-    image: dellemc/podmon:v1.7.0
-    controller:
-      args:
-        - "--csisock=unix:/var/run/csi/csi.sock"
-        - "--labelvalue=csi-vxflexos"
-        - "--mode=controller"
-        - "--skipArrayConnectionValidation=false"
-        - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
-    node:
-      args:
-        - "--csisock=unix:/var/lib/kubelet/plugins/vxflexos.emc.dell.com/csi_sock"
-        - "--labelvalue=csi-vxflexos"
-        - "--mode=node"
-        - "--leaderelection=false"
-        - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
   authorization:
     enabled: $AUTHORIZATION_ENABLED
-    sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
     proxyHost: $AUTHORIZATION_PROXY_HOST
     skipCertificateValidation: $AUTHORIZATION_SKIP_CERTIFICATE_VALIDATION
 
@@ -244,8 +183,7 @@ csi-vxflexos:
 csi-isilon:
   enabled: $POWERSCALE_ENABLED
   version: "v2.8.0"
-  images:
-    driverRepository: $IMAGE_REPOSITORY
+
   certSecretCount: $CERT_SECRET_COUNT
 
   allowedNetworks: []
@@ -267,7 +205,6 @@ csi-isilon:
 
     replication:
       enabled: $REPLICATION_ENABLED
-      image: dellemc/dell-csi-replicator:v1.5.0
 
     snapshot:
       enabled: $SNAPSHOT_ENABLED
@@ -318,45 +255,18 @@ csi-isilon:
 
   authorization:
     enabled: $AUTHORIZATION_ENABLED
-    sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
     proxyHost: $AUTHORIZATION_PROXY_HOST
     skipCertificateValidation: $AUTHORIZATION_SKIP_CERTIFICATE_VALIDATION
 
   # Enable this feature only after contact support for additional information
   podmon:
     enabled: $RESILIENCY_ENABLED
-    image: dellemc/podmon:v1.7.0
-    controller:
-      args:
-        - "--csisock=unix:/var/run/csi/csi.sock"
-        - "--labelvalue=csi-isilon"
-        - "--arrayConnectivityPollRate=60"
-        - "--driverPath=csi-isilon.dellemc.com"
-        - "--mode=controller"
-        - "--skipArrayConnectionValidation=false"
-        - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
-
-    node:
-      args:
-        - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
-        - "--labelvalue=csi-isilon"
-        - "--arrayConnectivityPollRate=60"
-        - "--driverPath=csi-isilon.dellemc.com"
-        - "--mode=node"
-        - "--leaderelection=false"
-        - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
 
 ## K8S/CSI-Unity ATTRIBUTES
 ##########################################
 csi-unity:
   enabled: $UNITY_ENABLED
   version: v2.8.0
-  images:
-    driverRepository: $IMAGE_REPOSITORY
   certSecretCount: $CERT_SECRET_COUNT
   fsGroupPolicy: $FSGROUP_POLICY
   controller:
@@ -409,27 +319,6 @@ csi-unity:
   maxUnityVolumesPerNode: $MAX_VOLUMES_PER_NODE
   podmon:
     enabled: $RESILIENCY_ENABLED
-    image: dellemc/podmon:v1.7.0
-    controller:
-      args:
-        - "--csisock=unix:/var/run/csi/csi.sock"
-        - "--labelvalue=csi-unity"
-        - "--driverPath=csi-unity.dellemc.com"
-        - "--mode=controller"
-        - "--skipArrayConnectionValidation=false"
-        - "--driver-config-params=/unity-config/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
-    node:
-      args:
-        - "--csisock=unix:/var/lib/kubelet/plugins/unity.emc.dell.com/csi_sock"
-        - "--labelvalue=csi-unity"
-        - "--driverPath=csi-unity.dellemc.com"
-        - "--mode=node"
-        - "--leaderelection=false"
-        - "--driver-config-params=/unity-config/driver-config-params.yaml"
-        - "--driverPodLabelValue=dell-storage"
-        - "--ignoreVolumelessPods=false"
 
 ## K8S/Replication Module ATTRIBUTES
 ##########################################


### PR DESCRIPTION
# Description
As part of the effort to centralize all the images in the same block I removed the references to the `image-registry`.

This field is not usable in real condition as we can only change the driver location and not the CSI sidecars.

# GitHub Issues
This is dependent on https://github.com/dell/helm-charts/pull/285

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

