### PR TITLE
Revert K8s 1.28 official support for replication/observability

### DIFF
--- a/content/docs/observability/_index.md
+++ b/content/docs/observability/_index.md
@@ -48,7 +48,7 @@ CSM for Observability provides the following capabilities:
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS | Supported Versions |
 |-|-|
-| Kubernetes    | 1.26, 1.27, 1.28 |
+| Kubernetes    | 1.25, 1.26, 1.27 |
 | Red Hat OpenShift | 4.11, 4.12, 4.13 |
 | Rancher Kubernetes Engine | yes |
 | RHEL          |     7.x, 8.x      |

--- a/content/docs/replication/_index.md
+++ b/content/docs/replication/_index.md
@@ -37,7 +37,7 @@ CSM for Replication provides the following capabilities:
 {{<table "table table-striped table-bordered table-sm">}}
 | COP/OS            | PowerMax         | PowerStore       | PowerScale       | PowerFlex        |
 | ----------------- | ---------------- | ---------------- | ---------------- | ---------------- |
-| Kubernetes        | 1.26, 1.27, 1.28 | 1.26, 1.27, 1.28 | 1.26, 1.27, 1.28 | 1.26, 1.27, 1.28 |
+| Kubernetes        | 1.25, 1.26, 1.27 | 1.25, 1.26, 1.27 | 1.25, 1.26, 1.27 | 1.25, 1.26, 1.27 |
 | Red Hat OpenShift | 4.12, 4.13       | 4.12, 4.13       | 4.12, 4.13       | 4.12, 4.13       |
 | RHEL              | 7.x, 8.x         | 7.x, 8.x         | 7.x, 8.x         | 7.x, 8.x         |
 | CentOS            | 7.8, 7.9         | 7.8, 7.9         | 7.8, 7.9         | 7.8, 7.9         |


### PR DESCRIPTION
# Description
Reverting K8s 1.28 official support for replication and observability modules.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/947 |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

