### PR TITLE
Improve instructions for Replication installations that utilize CSM Operator

### DIFF
--- a/content/docs/deployment/csmoperator/_index.md
+++ b/content/docs/deployment/csmoperator/_index.md
@@ -66,7 +66,7 @@ The installation process involves the creation of a `Subscription` object either
 git clone -b v1.3.0 https://github.com/dell/csm-operator.git
 ```
 3. `cd csm-operator`
-4. (Optional) If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
+4. _(Optional)_ If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
 5. Run `bash scripts/install.sh` to install the operator.
 
 >NOTE: Dell CSM Operator will be installed in the `dell-csm-operator` namespace.

--- a/content/docs/deployment/csmoperator/_index.md
+++ b/content/docs/deployment/csmoperator/_index.md
@@ -67,7 +67,22 @@ git clone -b v1.3.0 https://github.com/dell/csm-operator.git
 ```
 3. `cd csm-operator`
 4. _(Optional)_ If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
-5. Run `bash scripts/install.sh` to install the operator.
+5. _(Optional)_ If **CSM Replication** is planned for use and will be deployed using two clusters in an environment where the DNS is not configured, and cluster API endpoints are FQDNs, in order to resolve queries to remote API endpoints, it is necessary to edit the `deploy/operator.yaml` file and add the `hostAliases` field and associated `<FQDN>:<IP>` mappings to the CSM Operator Controller Manager Deployment under `spec.template.spec`. More information on host aliases can be found, [here](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/).
+    ```yaml
+    # example config
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: dell-csm-operator-controller-manager
+    spec:
+      template:
+        spec:
+          hostAliases:
+          - hostnames:
+            - "remote.FQDN"
+            ip: "255.255.255.1"
+    ```
+6. Run `bash scripts/install.sh` to install the operator.
 
 >NOTE: Dell CSM Operator will be installed in the `dell-csm-operator` namespace.
 

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -14,18 +14,18 @@ To configure Replication prior to installation via CSM Operator, you need:
 - a target cluster which will serve as the disaster recovery cluster
 > **_NOTE:_**  If using a single Kubernetes cluster in a stretched configuration, there will be only one cluster. The source cluster is also the target cluster.
 
-> **_NOTE:_** If **CSM Replication** is being deployed using two clusters in a environment where the DNS is not configured, and the cluster API endpoints are
-> FQDNs, it is necessary to add the `<FQDN>:<IP>` mapping in the /etc/hosts file in order to resolve queries to the remote API server.
-> This change will need to be made to the /etc/hosts file on:
-> - The bastion node(s) (or wherever `repctl` is used).
-> - Either the CSM Operator Deployment or ClusterServiceVersion custom resource if using an Operator Lifecycle Manager (such as with an OperatorHub install).
-> - Both dell-replication-controller-manager deployments.
-> 
-> To update the ClusterServiceVersion, execute the command below, replacing the fields for the remote cluster's FQDN and IP.
-> ```bash 
-> kubectl patch clusterserviceversions.operators.coreos.com -n <operator-namespace> dell-csm-operator-certified.v1.3.0 \
-> --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-cluster-ip>","hostnames":["<remote-FQDN>"]}]}]'
-> ```
+- _(Optional)_ If **CSM Replication** is being deployed using two clusters in a environment where the DNS is not configured, and the cluster API endpoints are
+FQDNs, it is necessary to add the `<FQDN>:<IP>` mapping in the /etc/hosts file in order to resolve queries to the remote API server.
+This change will need to be made to the /etc/hosts file on:
+    - The bastion node(s) (or wherever `repctl` is used).
+    - Either the CSM Operator Deployment or ClusterServiceVersion custom resource if using an Operator Lifecycle Manager (such as with an OperatorHub install).
+    - Both dell-replication-controller-manager deployments (covered in [Configuration Steps](#configuration-steps) below).
+
+    Update the ClusterServiceVersion before continuing. Execute the command below, replacing the fields for the remote cluster's FQDN and IP.
+    ```bash 
+    kubectl patch clusterserviceversions.operators.coreos.com -n <operator-namespace> dell-csm-operator-certified.v1.3.0 \
+    --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-cluster-ip>","hostnames":["<remote-FQDN>"]}]}]'
+    ```
 
 ### Cloning the GitHub Repository and Building repctl
 The [csm-replication](https://github.com/dell/csm-replication.git) GitHub repository is cloned to your source cluster as part of the installation. On your source cluster run the following to clone and build the repctl tool:
@@ -70,7 +70,7 @@ To configure Replication perform the following steps:
 
 7. Install the CSI driver for your chosen storage platform on the source cluster according to the instructions for [installing the drivers using CSM Operator](../../../csmoperator/drivers/#installing-csi-driver-via-operator).
 
-8. _(Optional)_ If **CSM Replication** is deployed using two clusters in an environment where the DNS is not configured, it is necessary to update the dell-replication-controller-manager Kubernetes deployment to map the API endpoint FQDN to an IP by adding the `hostAliases` field and associated FQDN:IP mappings.
+8. _(Optional)_ If **CSM Replication** is deployed using two clusters in an environment where the DNS is not configured, it is necessary to update the dell-replication-controller-manager Kubernetes deployment to map the API endpoint FQDN to an IP address by adding the `hostAliases` field and associated FQDN:IP mappings.
 
     To update the dell-replication-controller-manager deployment, execute the command below, replacing the fields for the remote cluster's FQDN and IP. Make sure to update the deployment on both the primary and disaster recovery clusters.
     ```bash

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -14,7 +14,7 @@ To configure Replication prior to installation via CSM Operator, you need:
 - a target cluster which will serve as the disaster recovery cluster
 > **_NOTE:_**  If using a single Kubernetes cluster in a stretched configuration, there will be only one cluster. The source cluster is also the target cluster.
 
-- _(Optional)_ If **CSM Replication** is being deployed using two clusters in a environment where the DNS is not configured, and the cluster API endpoints are
+- _(Optional)_ If CSM Replication is being deployed using two clusters in an environment where the DNS is not configured, and the cluster API endpoints are
 FQDNs, it is necessary to add the `<FQDN>:<IP>` mapping in the /etc/hosts file in order to resolve queries to the remote API server.
 This change will need to be made to the /etc/hosts file on:
     - The bastion node(s) (or wherever `repctl` is used).
@@ -24,7 +24,7 @@ This change will need to be made to the /etc/hosts file on:
     Update the ClusterServiceVersion before continuing. Execute the command below, replacing the fields for the remote cluster's FQDN and IP.
     ```bash 
     kubectl patch clusterserviceversions.operators.coreos.com -n <operator-namespace> dell-csm-operator-certified.v1.3.0 \
-    --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-cluster-ip>","hostnames":["<remote-FQDN>"]}]}]'
+    --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-IP>","hostnames":["<remote-FQDN>"]}]}]'
     ```
 
 ### Cloning the GitHub Repository and Building repctl
@@ -70,7 +70,7 @@ To configure Replication perform the following steps:
 
 7. Install the CSI driver for your chosen storage platform on the source cluster according to the instructions for [installing the drivers using CSM Operator](../../../csmoperator/drivers/#installing-csi-driver-via-operator).
 
-8. _(Optional)_ If **CSM Replication** is deployed using two clusters in an environment where the DNS is not configured, it is necessary to update the dell-replication-controller-manager Kubernetes deployment to map the API endpoint FQDN to an IP address by adding the `hostAliases` field and associated FQDN:IP mappings.
+8. _(Optional)_ If CSM Replication is deployed using two clusters in an environment where the DNS is not configured, it is necessary to update the dell-replication-controller-manager Kubernetes deployment to map the API endpoint FQDN to an IP address by adding the `hostAliases` field and associated FQDN:IP mappings.
 
     To update the dell-replication-controller-manager deployment, execute the command below, replacing the fields for the remote cluster's FQDN and IP. Make sure to update the deployment on both the primary and disaster recovery clusters.
     ```bash

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -17,7 +17,7 @@ To configure Replication prior to installation via CSM Operator, you need:
 ### Cloning the GitHub Repository and Building repctl
 The [csm-replication](https://github.com/dell/csm-replication.git) GitHub repository is cloned to your source cluster as part of the installation. On your source cluster run the following to clone and build the repctl tool:
 
-```
+```bash
 git clone -b v1.6.0 https://github.com/dell/csm-replication.git
 cd csm-replication/repctl
 make build

--- a/content/docs/deployment/csmoperator/modules/replication.md
+++ b/content/docs/deployment/csmoperator/modules/replication.md
@@ -14,6 +14,19 @@ To configure Replication prior to installation via CSM Operator, you need:
 - a target cluster which will serve as the disaster recovery cluster
 > **_NOTE:_**  If using a single Kubernetes cluster in a stretched configuration, there will be only one cluster. The source cluster is also the target cluster.
 
+> **_NOTE:_** If **CSM Replication** is being deployed using two clusters in a environment where the DNS is not configured, and the cluster API endpoints are
+> FQDNs, it is necessary to add the `<FQDN>:<IP>` mapping in the /etc/hosts file in order to resolve queries to the remote API server.
+> This change will need to be made to the /etc/hosts file on:
+> - The bastion node(s) (or wherever `repctl` is used).
+> - Either the CSM Operator Deployment or ClusterServiceVersion custom resource if using an Operator Lifecycle Manager (such as with an OperatorHub install).
+> - Both dell-replication-controller-manager deployments.
+> 
+> To update the ClusterServiceVersion, execute the command below, replacing the fields for the remote cluster's FQDN and IP.
+> ```bash 
+> kubectl patch clusterserviceversions.operators.coreos.com -n <operator-namespace> dell-csm-operator-certified.v1.3.0 \
+> --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-cluster-ip>","hostnames":["<remote-FQDN>"]}]}]'
+> ```
+
 ### Cloning the GitHub Repository and Building repctl
 The [csm-replication](https://github.com/dell/csm-replication.git) GitHub repository is cloned to your source cluster as part of the installation. On your source cluster run the following to clone and build the repctl tool:
 
@@ -56,3 +69,11 @@ To configure Replication perform the following steps:
 6. On the target cluster, configure the [prerequisites](../../../csmoperator/drivers/#pre-requisites-for-installation-of-the-csi-drivers) for deploying the driver via Dell CSM Operator.
 
 7. Install the CSI driver for your chosen storage platform on the source cluster according to the instructions for [installing the drivers using CSM Operator](../../../csmoperator/drivers/#installing-csi-driver-via-operator).
+
+8. _(Optional)_ If **CSM Replication** is deployed using two clusters in an environment where the DNS is not configured, it is necessary to update the dell-replication-controller-manager Kubernetes deployment to map the API endpoint FQDN to an IP by adding the `hostAliases` field and associated FQDN:IP mappings.
+
+    To update the dell-replication-controller-manager deployment, execute the command below, replacing the fields for the remote cluster's FQDN and IP. Make sure to update the deployment on both the primary and disaster recovery clusters.
+    ```bash
+    kubectl patch deployment -n dell-replication-controller dell-replication-controller-manager \
+    -p '{"spec":{"template":{"spec":{"hostAliases":[{"hostnames":["<remote-FQDN>"],"ip":"<remote-IP>"}]}}}}'
+    ```

--- a/content/docs/deployment/csmoperator/troubleshooting/_index.md
+++ b/content/docs/deployment/csmoperator/troubleshooting/_index.md
@@ -60,7 +60,7 @@ Typical reasons for errors:
 * Incorrect RBAC permissions
 
 ### My CSM Replication install fails to validate replication prechecks with 'no such host'.
-In replication environments that utilize more than one cluster, and utilize FQDNs to reference API endpoints, it is highly recommended that the DNS be configured to resolve requests involving the FQDN to the appropriate Kubernetes cluster.
+In replication environments that utilize more than one cluster, and utilize FQDNs to reference API endpoints, it is highly recommended that the DNS be configured to resolve requests involving the FQDN to the appropriate cluster.
 
 If for some reason it is not possible to configure the DNS, the /etc/hosts file should be updated to map the FQDN to the appropriate IP. This change will need to be made to the /etc/hosts file on:
 - The bastion node(s) (or wherever `repctl` is used).
@@ -70,7 +70,7 @@ If for some reason it is not possible to configure the DNS, the /etc/hosts file 
 To update the ClusterServiceVersion, execute the command below, replacing the fields for the remote cluster's FQDN and IP.
 ```bash
 kubectl patch clusterserviceversions.operators.coreos.com -n <operator-namespace> dell-csm-operator-certified.v1.3.0 \
-> --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-cluster-ip>","hostnames":["<remote-FQDN>"]}]}]'
+--type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-IP>","hostnames":["<remote-FQDN>"]}]}]'
 ```
 
 To update the dell-replication-controller-manager deployment, execute the command below, replacing the fields for the remote cluster's FQDN and IP. Make sure to update the deployment on both the primary and disaster recovery clusters.

--- a/content/docs/deployment/csmoperator/troubleshooting/_index.md
+++ b/content/docs/deployment/csmoperator/troubleshooting/_index.md
@@ -15,8 +15,8 @@ weight: 3
 The Dell CSM Operator is unable to manage any existing driver installed using Helm charts or the Dell CSI Operator. If you already have installed one of the Dell CSI driver in your cluster and  want to use the CSM operator based deployment, uninstall the driver and then redeploy the driver via Dell CSM Operator
 
 
-### Why does some of the Custom Resource fields show up as invalid or unsupported in the OperatorHub GUI?
-The Dell CSM Operator is not fully compliant with the OperatorHub React UI elements.Due to this, some of the Custom Resource fields may show up as invalid or unsupported in the OperatorHub GUI. To get around this problem, use `kubectl/oc` commands to get details about the Custom Resource(CR). This issue will be fixed in the upcoming releases of the Dell CSM Operator.
+### Why do some of the Custom Resource fields show up as invalid or unsupported in the OperatorHub GUI?
+The Dell CSM Operator is not fully compliant with the OperatorHub React UI elements. Due to this, some of the Custom Resource fields may show up as invalid or unsupported in the OperatorHub GUI. To get around this problem, use `kubectl/oc` commands to get details about the Custom Resource(CR). This issue will be fixed in the upcoming releases of the Dell CSM Operator.
 
 ### How can I view detailed logs for the CSM Operator?
 Detailed logs of the CSM Operator can be displayed using the following command:

--- a/content/docs/deployment/csmoperator/troubleshooting/_index.md
+++ b/content/docs/deployment/csmoperator/troubleshooting/_index.md
@@ -10,6 +10,7 @@ weight: 3
   - [Why does some of the Custom Resource fields show up as invalid or unsupported in the OperatorHub GUI?](#why-does-some-of-the-custom-resource-fields-show-up-as-invalid-or-unsupported-in-the-operatorhub-gui)
   - [How can I view detailed logs for the CSM Operator?](#how-can-i-view-detailed-logs-for-the-csm-operator)
   - [My Dell CSI Driver install failed. How do I fix it?](#my-dell-csi-driver-install-failed-how-do-i-fix-it)
+  - [My Dell CSM Replication install failed to validate replication prechecks with 'no such host'.](#my-dell-csm-replication-install-failed-to-validate-replication-prechecks-with-no-such-host)
 
 ### Can CSM Operator manage existing drivers installed using Helm charts or the Dell CSI Operator?
 The Dell CSM Operator is unable to manage any existing driver installed using Helm charts or the Dell CSI Operator. If you already have installed one of the Dell CSI driver in your cluster and  want to use the CSM operator based deployment, uninstall the driver and then redeploy the driver via Dell CSM Operator
@@ -57,4 +58,23 @@ Typical reasons for errors:
 * Incorrect driver type
 * Incorrect driver Spec env, args for containers
 * Incorrect RBAC permissions
-	
+
+### My CSM Replication install fails to validate replication prechecks with 'no such host'.
+In replication environments that utilize more than one cluster, and utilize FQDNs to reference API endpoints, it is highly recommended that the DNS be configured to resolve requests involving the FQDN to the appropriate Kubernetes cluster.
+
+If for some reason it is not possible to configure the DNS, the /etc/hosts file should be updated to map the FQDN to the appropriate IP. This change will need to be made to the /etc/hosts file on:
+- The bastion node(s) (or wherever `repctl` is used).
+- Either the CSM Operator Deployment or ClusterServiceVersion custom resource if using an Operator Lifecycle Manager (such as with an OperatorHub install).
+- Both dell-replication-controller-manager deployments.
+
+To update the ClusterServiceVersion, execute the command below, replacing the fields for the remote cluster's FQDN and IP.
+```bash
+kubectl patch clusterserviceversions.operators.coreos.com -n <operator-namespace> dell-csm-operator-certified.v1.3.0 \
+> --type=json -p='[{"op": "add", "path": "/spec/install/spec/deployments/0/spec/template/spec/hostAliases", "value": [{"ip":"<remote-cluster-ip>","hostnames":["<remote-FQDN>"]}]}]'
+```
+
+To update the dell-replication-controller-manager deployment, execute the command below, replacing the fields for the remote cluster's FQDN and IP. Make sure to update the deployment on both the primary and disaster recovery clusters.
+```bash
+kubectl patch deployment -n dell-replication-controller dell-replication-controller-manager \
+-p '{"spec":{"template":{"spec":{"hostAliases":[{"hostnames":["<remote-FQDN>"],"ip":"<remote-IP>"}]}}}}'
+```

--- a/content/docs/deployment/csmoperator/troubleshooting/_index.md
+++ b/content/docs/deployment/csmoperator/troubleshooting/_index.md
@@ -10,7 +10,7 @@ weight: 3
   - [Why does some of the Custom Resource fields show up as invalid or unsupported in the OperatorHub GUI?](#why-does-some-of-the-custom-resource-fields-show-up-as-invalid-or-unsupported-in-the-operatorhub-gui)
   - [How can I view detailed logs for the CSM Operator?](#how-can-i-view-detailed-logs-for-the-csm-operator)
   - [My Dell CSI Driver install failed. How do I fix it?](#my-dell-csi-driver-install-failed-how-do-i-fix-it)
-  - [My Dell CSM Replication install failed to validate replication prechecks with 'no such host'.](#my-dell-csm-replication-install-failed-to-validate-replication-prechecks-with-no-such-host)
+  - [My CSM Replication install fails to validate replication prechecks with 'no such host'.](#my-csm-replication-install-fails-to-validate-replication-prechecks-with-no-such-host)
 
 ### Can CSM Operator manage existing drivers installed using Helm charts or the Dell CSI Operator?
 The Dell CSM Operator is unable to manage any existing driver installed using Helm charts or the Dell CSI Operator. If you already have installed one of the Dell CSI driver in your cluster and  want to use the CSM operator based deployment, uninstall the driver and then redeploy the driver via Dell CSM Operator


### PR DESCRIPTION
# Description
Adding instructions for operator-initiated replication installations to create host aliases in deployed workloads. These additional host aliases will help resolve requests to API endpoints in remote clusters in environments where the DNS service is not configured to do so.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/988 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] ~Have you added high-resolution images?~ Not applicable

