### PR TITLE
Updated supported versions of PowerScale

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -58,7 +58,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 {{<table "table table-striped table-bordered table-sm">}}
 |               | PowerMax                                                | PowerFlex        | Unity XT                   | PowerScale                         |    PowerStore    |
 |---------------|:-------------------------------------------------------:|:----------------:|:--------------------------:|:----------------------------------:|:----------------:|
-| Storage Array | PowerMax 2500/8500 PowerMaxOS 10 (6079) , PowerMaxOS 10.0.1 (6079) <br> PowerMax 2000/8000 - 5978.711.xxx, 5978.479.xxx <br>Unisphere 10.0,10.0.1 |    3.5.x, 3.6.x, 4.0.x, 4.5  | 5.1.x, 5.2.x, 5.3.0 | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5.0.4 | 2.0.x, 2.1.x, 3.0, 3.2, 3.5     |
+| Storage Array | PowerMax 2500/8500 PowerMaxOS 10 (6079) , PowerMaxOS 10.0.1 (6079) <br> PowerMax 2000/8000 - 5978.711.xxx, 5978.479.xxx <br>Unisphere 10.0,10.0.1 |    3.5.x, 3.6.x, 4.0.x, 4.5  | 5.1.x, 5.2.x, 5.3.0 | OneFS 8.1, 8.2, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5.0.5, 9.5.0.6 | 2.0.x, 2.1.x, 3.0, 3.2, 3.5     |
 {{</table>}}
 
 >Note: To connect to a PowerFlex 4.5 array, the SDC image will need to be changed to dellemc/sdc:4.5.


### PR DESCRIPTION
# Description
Change already went into main.  This is to put the change in the release-1.9.0 branch.  Documentation points to PowerScale 9.5.0.4, which is no longer available.  This PR updates the PowerScale supported versions by added 9.5.0.5 and 9.5.0.6.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1012 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

