### PR TITLE
Feature 996 link migration steps op driver

### DIFF
--- a/content/docs/csidriver/installation/operator/operator_migration.md
+++ b/content/docs/csidriver/installation/operator/operator_migration.md
@@ -30,7 +30,7 @@ description: >
       kubectl -n openshift-operators get CSIUnity/test-unity -o yaml
   ```
 2. Map and update the settings from the CR in step 1 to the relevant CSM Operator CR
-    - As the yaml content may differ, ensure the values held in the step 1 CR backup are present in the new CR before installing the new driver
+    - As the yaml content may differ, ensure the values held in the step 1 CR backup are present in the new CR before installing the new driver. CR Samples table provided above can be used to compare and map the differences in attributes between Dell CSI Operator and CSM Operator CRs
         - Ex: spec.driver.fsGroupPolicy in [PowerMax 2.6 for CSI Operator](https://github.com/dell/dell-csi-operator/blob/main/samples/powermax_v260_k8s_126.yaml#L17C5-L17C18) maps to spec.driver.csiDriverSpec.fSGroupPolicy in [PowerMax 2.6 for CSM Operator](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_v260.yaml#L28C7-L28C20)
 3. Retain (or do not delete) the secret, namespace, storage classes, and volume snapshot classes from the original deployment as they will be re-used in the CSM operator deployment
 4. Uninstall the CR from the CSI Operator


### PR DESCRIPTION
# Description
- Added references to the common migration steps page created  wherever there is a deprecation notice
- Updated v1 folder with the same changes as it contains the deprecation notice as well

Most of the original changes done as part of this PR are covered as part of PR https://github.com/dell/csm-docs/pull/887/files
Just keeping the diff after resolving conflicts. We can avoid merging this PR if the diff content need not go into the base branch

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/996|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

