### PR TITLE
Fix interactive form, no tag menu, add images in template

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ defaultContentLanguage = "en"
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy", "taxonomyTerm", "term"]
 
 # Highlighting config
 pygmentsCodeFences = true

--- a/content/docs/deployment/csminstallationwizard/src/index.html
+++ b/content/docs/deployment/csminstallationwizard/src/index.html
@@ -68,11 +68,11 @@
 
                 <!-- main content starts -->
                 <div id="main">
-                  <div id="image-repository" class="was-validated row mb-4 image-repository" style="display: none;">
+                  <div class="was-validated row mb-4 image-repository">
                     <label for="image-repository" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Specify the registry from where the image should be pulled" style="width: 150px;">Image Repository</label>
                     <div class="col-sm-9"></div>
                     <div class="col-sm-3">
-                      <input class="form-control input-lg" type="text" id="image-repository" placeholder="dellemc"  onchange="onCSMVersionChange();" oninput="validateInput(validateForm, CONSTANTS)" required>
+                      <input class="form-control input-lg" type="text" id="image-repository" placeholder="dellemc" oninput="validateInput(validateForm, CONSTANTS)" required>
                     </div>
                     <div class="col-sm-4">
                       <div class="row mt-1">

--- a/content/docs/deployment/csminstallationwizard/src/static/js/ui-functions.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/ui-functions.js
@@ -89,6 +89,7 @@ function onArrayChange() {
 		onReplicationChange(replicationNote);
 		validateInput(validateForm, CONSTANTS);
 		onRenameSDCChange(driver, CONSTANTS);
+		hideImageRepo($("#csm-version").val());
 	});
 }
 
@@ -223,9 +224,20 @@ function onRenameSDCChange(driverName, CONSTANTS_PARAM) {
 	}
 }
 
+const hideImageRepo = (csmVersion) => {
+	console.log("cs",csmVersion)
+	if (csmVersion === "1.8.0" || csmVersion === "1.7.0"){
+		$(".image-repository").show();
+	} else {
+		$(".image-repository").hide();
+	}
+}
+
 const onCSMVersionChange = () => {
-	document.getElementById("csm-version").value !== ""? loadTemplate(document.getElementById("array").value, document.getElementById("installation-type").value, document.getElementById("csm-version").value) : null;
+	csmVersion = document.getElementById("csm-version").value;
+	csmVersion !== ""? loadTemplate(document.getElementById("array").value, document.getElementById("installation-type").value, document.getElementById("csm-version").value) : null;
 	displayModules(installationType, driver, CONSTANTS);
+	hideImageRepo(csmVersion);
 	onObservabilityChange();
 	onObservabilityOperatorChange();
 	onAuthorizationChange();
@@ -526,7 +538,6 @@ function onPageLoad() {
 	hideFields();
 	loadDefaultValues();
 	$("#command-text-area").hide();
-
 	onArrayChange();
 	onCopyButtonClick();
 	downloadFileHandler();

--- a/content/docs/deployment/csminstallationwizard/src/static/js/ui-functions.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/ui-functions.js
@@ -225,7 +225,6 @@ function onRenameSDCChange(driverName, CONSTANTS_PARAM) {
 }
 
 const hideImageRepo = (csmVersion) => {
-	console.log("cs",csmVersion)
 	if (csmVersion === "1.8.0" || csmVersion === "1.7.0"){
 		$(".image-repository").show();
 	} else {

--- a/content/docs/deployment/csminstallationwizard/src/static/js/utility.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/utility.js
@@ -156,6 +156,5 @@ if (typeof exports !== 'undefined') {
 		validateForm,
 		setMap,
 		setDefaultValues,
-		onCSMVersionChange,
 	};
 }

--- a/content/docs/deployment/csminstallationwizard/src/static/js/utility.js
+++ b/content/docs/deployment/csminstallationwizard/src/static/js/utility.js
@@ -138,17 +138,6 @@ function setDefaultValues(defaultValuesParam, csmMapValues) {
 
 }
 
-function onCSMVersionChange() {
-    var selectedVersion = document.getElementById('csm-version').value;
-    var imageRepoSection = document.getElementById('image-repository');
-
-    if (selectedVersion === '1.8.0' || selectedVersion === '1.7.0') {
-        imageRepoSection.style.display = '';
-    } else {
-        imageRepoSection.style.display = 'none';
-    }
-}
-
 function setMap(str) {
 	const testMap = new Map();
 	var keyValues = str.split('\n');

--- a/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.9.0-values.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.9.0-values.template
@@ -5,6 +5,22 @@
 csi-powerstore:
   enabled: $POWERSTORE_ENABLED
   version: v2.9.0
+  images:
+    # "driver" defines the container image, used for the driver container.
+    driver: dellemc/csi-powerstore:v2.9.0
+    # CSI sidecars
+    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2
+    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
+    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
+
+    # CSM sidecars
+    replication: dellemc/dell-csi-replicator:v1.6.0
+    vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.4.0
+    podmon: dellemc/podmon:v1.7.0
+    metadataretriever: dellemc/csi-metadata-retriever:v1.6.0
   ## Controller ATTRIBUTES
   controller:
     controllerCount: $CONTROLLER_COUNT
@@ -75,6 +91,22 @@ csi-powermax:
       - endpoint: $POWERMAX_MANAGEMENT_SERVERS_ENDPOINT_URL
       - endpoint: $TARGET_UNISPHERE
   version: v2.9.0
+  images:
+    # "driver" defines the container image, used for the driver container.
+    driver: dellemc/csi-powermax:v2.8.0
+    csireverseproxy: dellemc/csipowermax-reverseproxy:v2.7.0
+    # CSI sidecars
+    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
+    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
+    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.0
+    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
+    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
+    # CSM sidecars
+    replication: dellemc/dell-csi-replicator:v1.6.0
+    authorization: dellemc/csm-authorization-sidecar:v1.9.0
+    migration: dellemc/dell-csi-migrator:v1.2.0
+    noderescan: dellemc/dell-csi-node-rescanner:v1.1.0
   clusterPrefix: $POWERMAX_CLUSTER_PREFIX
   portGroups: "$POWERMAX_PORT_GROUPS"
   fsGroupPolicy: "$FSGROUP_POLICY"
@@ -135,6 +167,23 @@ csi-powermax:
 csi-vxflexos:
   enabled: $POWERFLEX_ENABLED
   version: v2.9.0
+  images:
+    # "driver" defines the container image, used for the driver container.
+    driver: dellemc/csi-vxflexos:v2.9.0
+    # "powerflexSdc" defines the SDC image for init container.
+    powerflexSdc: dellemc/sdc:4.5
+    # CSI sidecars
+    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.4.2
+    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.6.2
+    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.2
+    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.9.2
+    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.1
+    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
+    # CSM sidecars
+    replication: dellemc/dell-csi-replicator:v1.6.0
+    vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.4.0
+    podmon: dellemc/podmon:v1.7.0
+    authorization: dellemc/csm-authorization-sidecar:v1.8.0
   certSecretCount: $CERT_SECRET_COUNT
   controller:
     replication:
@@ -199,40 +248,42 @@ csi-isilon:
   enabled: $POWERSCALE_ENABLED
   version: "v2.8.0"
   images:
-    driverRepository: $IMAGE_REPOSITORY
+    # "driver" defines the container image, used for the driver container.
+    driver: dellemc/csi-isilon:v2.8.0
+    # CSI sidecars
+    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
+    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
+    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.0
+    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
+    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
+    # CSM sidecars
+    replication: dellemc/dell-csi-replicator:v1.6.0
+    podmon: dellemc/podmon:v1.8.0
+    authorization: dellemc/csm-authorization-sidecar:v1.8.0
+    metadataretriever: dellemc/csi-metadata-retriever:v1.4.0
+    encryption: dellemc/csm-encryption:v0.3.0
+
   certSecretCount: $CERT_SECRET_COUNT
-
   allowedNetworks: []
- 
   verbose: 1
-
   enableCustomTopology: false
-
   fsGroupPolicy: $FSGROUP_POLICY
-
   storageCapacity:
     enabled: $STORAGE_CAPACITY_ENABLED
-
   maxIsilonVolumesPerNode: $MAX_VOLUMES_PER_NODE
-
   controller:
     controllerCount: $CONTROLLER_COUNT
     volumeNamePrefix: $VOLUME_NAME_PREFIX
-
     replication:
       enabled: $REPLICATION_ENABLED
-      image: dellemc/dell-csi-replicator:v1.6.0
-
     snapshot:
       enabled: $SNAPSHOT_ENABLED
       snapNamePrefix: $SNAP_NAME_PREFIX
-
     resizer:
       enabled: $RESIZER_ENABLED
-
     healthMonitor:
       enabled: $HEALTH_MONITOR_ENABLED
-
     nodeSelector: $CONTROLLER_POD_NODE_SELECTOR
     tolerations: $CONTROLLER_TOLERATIONS
   node:
@@ -269,12 +320,10 @@ csi-isilon:
 
     healthMonitor:
       enabled: $HEALTH_MONITOR_ENABLED
-
   authorization:
     enabled: $AUTHORIZATION_ENABLED
     proxyHost: $AUTHORIZATION_PROXY_HOST
     skipCertificateValidation: $AUTHORIZATION_SKIP_CERTIFICATE_VALIDATION
-
   # Enable this feature only after contact support for additional information
   podmon:
     enabled: $RESILIENCY_ENABLED
@@ -283,7 +332,19 @@ csi-isilon:
 ##########################################
 csi-unity:
   enabled: $UNITY_ENABLED
-  version: v2.8.0
+  version: v2.9.0
+  images:
+    # "driver" defines the container image, used for the driver container.
+    driver: dellemc/csi-unity:v2.9.0
+    # CSI sidecars
+    attacher: registry.k8s.io/sig-storage/csi-attacher:v4.4.0
+    provisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.6.0
+    snapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.0
+    resizer: registry.k8s.io/sig-storage/csi-resizer:v1.9.0
+    registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
+    healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
+    # CSM sidecars
+    podmon: dellemc/podmon:v1.7.0
   certSecretCount: $CERT_SECRET_COUNT
   fsGroupPolicy: $FSGROUP_POLICY
   controller:


### PR DESCRIPTION
# Description
Previous version was displaying the entire form, now fixed in the javascript

Per request, add all `images` tags to the template

The tags on the left menu prevent to launch the `Interactive Tutorial`

# GitHub Issues

- https://github.com/dell/csm/issues/1055
- https://github.com/dell/csm/issues/1012

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

