### PR TITLE
PowerFlex: Added fixed issue for PowerFlex Dockerfile is incorrectly labeling the version as 2.7.0 for the 2.8.0 version

### DIFF
--- a/content/docs/csidriver/release/powerflex.md
+++ b/content/docs/csidriver/release/powerflex.md
@@ -18,6 +18,7 @@ description: Release notes for PowerFlex CSI driver
 - [#1014 - [BUG]: Missing error check for os.Stat call during volume publish](https://github.com/dell/csm/issues/1014)
 - [#1020 - [BUG]: SDC Rename ](https://github.com/dell/csm/issues/1020)
 - [#1030 - [BUG]: Comment out duplicate entries in the sample secret.yaml file](https://github.com/dell/csm/issues/1030)
+- [#1054 - [BUG]: The PowerFlex Dockerfile is incorrectly labeling the version as 2.7.0 for the 2.8.0 version](https://github.com/dell/csm/issues/1054)
 
 ### Known Issues
 
@@ -29,7 +30,6 @@ description: Release notes for PowerFlex CSI driver
 | sdc:3.6.1 is causing issues while installing the csi-powerflex driver on ubuntu.                                           |  Workaround: <br /> Change the powerflexSdc to sdc:3.6 in values.yaml https://github.com/dell/csi-powerflex/blob/72b27acee7553006cc09df97f85405f58478d2e4/helm/csi-vxflexos/values.yaml#L13 <br />|
 A CSI ephemeral pod may not get created in OpenShift 4.13 and fail with the error `"error when creating pod: the pod uses an inline volume provided by CSIDriver csi-vxflexos.dellemc.com, and the namespace has a pod security enforcement level that is lower than privileged."` | This issue occurs because OpenShift 4.13 introduced the CSI Volume Admission plugin to restrict the use of a CSI driver capable of provisioning CSI ephemeral volumes during pod admission. Therefore, an additional label `security.openshift.io/csi-ephemeral-volume-profile` in [csidriver.yaml](https://github.com/dell/helm-charts/blob/csi-vxflexos-2.9.0/charts/csi-vxflexos/templates/csidriver.yaml) file with the required security profile value should be provided. Follow [OpenShift 4.13 documentation for CSI Ephemeral Volumes](https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/ephemeral-storage-csi-inline.html) for more information. |
 | If the volume limit is exhausted and there are pending pods and PVCs due to `exceed max volume count`, the pending PVCs will be bound to PVs and the pending pods will be scheduled to nodes when the driver pods are restarted. | It is advised not to have any pending pods or PVCs once the volume limit per node is exhausted on a CSI Driver. There is an open issue reported with kubenetes at https://github.com/kubernetes/kubernetes/issues/95911 with the same behavior. |
-| The PowerFlex Dockerfile is incorrectly labeling the version as 2.7.0 for the 2.8.0 version.  |  Describe the driver pod using ```kubectl describe pod $podname -n vxflexos``` to ensure v2.8.0 is installed. |
 
 ### Note:
 


### PR DESCRIPTION
# Description
Added fixed issue: PowerFlex Dockerfile is incorrectly labeling the version as 2.7.0 for the 2.8.0 version

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1054 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

