### PR TITLE
[feature-1012]: Update Authorization and Resiliency for CSM v1.9.0

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -73,9 +73,9 @@ CSM is made up of multiple components including modules (enterprise capabilities
 
 | CSM Module                                                  | CSI PowerFlex v2.9.0 | CSI PowerScale v2.9.0 | CSI PowerStore v2.9.0 | CSI PowerMax v2.9.0 | CSI Unity XT v2.9.0 |
 | ----------------------------------------------------------- | -------------------- | --------------------- | --------------------- | ------------------- | ------------------- |
-| [**Authorization**](authorization/) v1.8.0                  | ✔️                    | ✔️                     | ❌                     | ✔️                   | ❌                   |
+| [**Authorization**](authorization/) v1.9.0                  | ✔️                    | ✔️                     | ❌                     | ✔️                   | ❌                   |
 | [**Observability**](observability/) v1.6.0                  | ✔️                    | ✔️                     | ✔️                     | ✔️                   | ❌                   |
 | [**Replication**](replication/)   v1.6.0                    | ✔️                    | ✔️                     | ✔️                     | ✔️                   | ❌                   |
-| [**Resiliency**](resiliency/)     v1.7.0                    | ✔️                    | ✔️                     | ✔️                     | ❌                   | ✔️                   |
+| [**Resiliency**](resiliency/)     v1.8.0                    | ✔️                    | ✔️                     | ✔️                     | ❌                   | ✔️                   |
 | [**Encryption**](secure/encryption)    v0.4.0               | ❌                    | ✔️                     | ❌                     | ❌                   | ❌                   |
 | [**Application Mobility**](applicationmobility/)     v0.4.0 | ✔️                    | ✔️                     | ✔️                     | ✔️                   | ✔️                   |

--- a/content/docs/authorization/_index.md
+++ b/content/docs/authorization/_index.md
@@ -73,6 +73,7 @@ CSM for Authorization consists of 2 components - the Authorization sidecar and t
 | dellemc/csm-authorization-sidecar:v1.6.0 | v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.5.1, v1.6.0 |
 | dellemc/csm-authorization-sidecar:v1.7.0 | v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.5.1, v1.6.0, v1.7.0 |
 | dellemc/csm-authorization-sidecar:v1.8.0 | v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.5.1, v1.6.0, v1.7.0, v1.8.0 |
+| dellemc/csm-authorization-sidecar:v1.9.0 | v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.5.1, v1.6.0, v1.7.0, v1.8.0, v1.9.0 |
 {{</table>}}
 ## Roles and Responsibilities
 

--- a/content/docs/authorization/configuration/powerflex/_index.md
+++ b/content/docs/authorization/configuration/powerflex/_index.md
@@ -119,8 +119,8 @@ Given a setup where Kubernetes, a storage system, and the CSM for Authorization 
       enabled: true
 
       # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
-      # Default value: dellemc/csm-authorization-sidecar:v1.8.0
-      sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
+      # Default value: dellemc/csm-authorization-sidecar:v1.9.0
+      sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.9.0
 
       # proxyHost: hostname of the csm-authorization server
       # Default value: None
@@ -156,10 +156,10 @@ Given a setup where Kubernetes, a storage system, and the CSM for Authorization 
       - name: authorization
         # enable: Enable/Disable csm-authorization
         enabled: true
-        configVersion: v1.8.0
+        configVersion: v1.9.0
         components:
         - name: karavi-authorization-proxy
-          image: dellemc/csm-authorization-sidecar:v1.8.0
+          image: dellemc/csm-authorization-sidecar:v1.9.0
           envs:
             # proxyHost: hostname of the csm-authorization server
             - name: "PROXY_HOST"

--- a/content/docs/authorization/configuration/powermax/_index.md
+++ b/content/docs/authorization/configuration/powermax/_index.md
@@ -85,8 +85,8 @@ Create the karavi-authorization-config secret using this command:
       enabled: true
 
       # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
-      # Default value: dellemc/csm-authorization-sidecar:v1.8.0
-      sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
+      # Default value: dellemc/csm-authorization-sidecar:v1.9.0
+      sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.9.0
 
       # proxyHost: hostname of the csm-authorization server
       # Default value: None
@@ -98,6 +98,42 @@ Create the karavi-authorization-config secret using this command:
       #   "false" - TLS certificate will be verified 
       # Default value: "true" 
       skipCertificateValidation: true
+    ```
+
+    **Operator**
+
+    Refer to the [Install Driver](../../../deployment/csmoperator/drivers/powermax/#install-driver) section to edit the parameters in the Custom Resource to enable CSM Authorization.
+
+    Under `modules`, enable the module named `authorization`:
+
+    - Update the `enabled` field to `true.`
+
+    - Update the `image` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
+
+    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server.
+
+    - Update the `SKIP_CERTIFICATE_VALIDATION` environment value to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
+
+    Example: 
+
+    ```yaml
+    modules:
+      # Authorization: enable csm-authorization for RBAC
+      - name: authorization
+        # enable: Enable/Disable csm-authorization
+        enabled: true
+        configVersion: v1.9.0
+        components:
+        - name: karavi-authorization-proxy
+          image: dellemc/csm-authorization-sidecar:v1.9.0
+          envs:
+            # proxyHost: hostname of the csm-authorization server
+            - name: "PROXY_HOST"
+              value: "csm-authorization.com"
+          
+            # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server       
+            - name: "SKIP_CERTIFICATE_VALIDATION"
+              value: "true"
     ```
 
 5. Install the Dell CSI PowerMax driver following the appropriate documenation for your installation method.

--- a/content/docs/authorization/configuration/powerscale/_index.md
+++ b/content/docs/authorization/configuration/powerscale/_index.md
@@ -127,8 +127,8 @@ kubectl -n isilon create secret generic karavi-authorization-config --from-file=
       enabled: true
 
       # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
-      # Default value: dellemc/csm-authorization-sidecar:v1.8.0
-      sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.8.0
+      # Default value: dellemc/csm-authorization-sidecar:v1.9.0
+      sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.9.0
 
       # proxyHost: hostname of the csm-authorization server
       # Default value: None
@@ -162,10 +162,10 @@ kubectl -n isilon create secret generic karavi-authorization-config --from-file=
       - name: authorization
         # enable: Enable/Disable csm-authorization
         enabled: true
-        configVersion: v1.8.0
+        configVersion: v1.9.0
         components:
         - name: karavi-authorization-proxy
-          image: dellemc/csm-authorization-sidecar:v1.8.0
+          image: dellemc/csm-authorization-sidecar:v1.9.0
           envs:
             # proxyHost: hostname of the csm-authorization server
             - name: "PROXY_HOST"

--- a/content/docs/csidriver/installation/offline/_index.md
+++ b/content/docs/csidriver/installation/offline/_index.md
@@ -90,7 +90,7 @@ bash scripts/csm-offline-bundle.sh -c
    dellemc/csi-powerstore:v2.9.0
    dellemc/csi-unity:v2.8.0
    dellemc/csi-vxflexos:v2.9.0
-   dellemc/csm-authorization-sidecar:v1.7.0
+   dellemc/csm-authorization-sidecar:v1.9.0
    dellemc/csm-metrics-powerflex:v1.5.0
    dellemc/csm-metrics-powerscale:v1.2.0
    dellemc/csm-topology:v1.5.0

--- a/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.9.0-values.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/helm/csm-1.9.0-values.template
@@ -19,7 +19,7 @@ csi-powerstore:
     # CSM sidecars
     replication: dellemc/dell-csi-replicator:v1.6.0
     vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.4.0
-    podmon: dellemc/podmon:v1.7.0
+    podmon: dellemc/podmon:v1.8.0
     metadataretriever: dellemc/csi-metadata-retriever:v1.6.0
   ## Controller ATTRIBUTES
   controller:
@@ -182,8 +182,8 @@ csi-vxflexos:
     # CSM sidecars
     replication: dellemc/dell-csi-replicator:v1.6.0
     vgsnapshotter: dellemc/csi-volumegroup-snapshotter:v1.4.0
-    podmon: dellemc/podmon:v1.7.0
-    authorization: dellemc/csm-authorization-sidecar:v1.8.0
+    podmon: dellemc/podmon:v1.8.0
+    authorization: dellemc/csm-authorization-sidecar:v1.9.0
   certSecretCount: $CERT_SECRET_COUNT
   controller:
     replication:
@@ -260,7 +260,7 @@ csi-isilon:
     # CSM sidecars
     replication: dellemc/dell-csi-replicator:v1.6.0
     podmon: dellemc/podmon:v1.8.0
-    authorization: dellemc/csm-authorization-sidecar:v1.8.0
+    authorization: dellemc/csm-authorization-sidecar:v1.9.0
     metadataretriever: dellemc/csi-metadata-retriever:v1.4.0
     encryption: dellemc/csm-encryption:v0.3.0
 
@@ -344,7 +344,7 @@ csi-unity:
     registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.9.0
     healthmonitor: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.10.0
     # CSM sidecars
-    podmon: dellemc/podmon:v1.7.0
+    podmon: dellemc/podmon:v1.8.0
   certSecretCount: $CERT_SECRET_COUNT
   fsGroupPolicy: $FSGROUP_POLICY
   controller:

--- a/content/docs/deployment/csminstallationwizard/src/templates/operator/csm-isilon-1.9.0.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/operator/csm-isilon-1.9.0.template
@@ -245,10 +245,10 @@ spec:
     - name: authorization
       # enable: Enable/Disable csm-authorization
       enabled: $AUTHORIZATION_ENABLED
-      configVersion: v1.8.0
+      configVersion: v1.9.0
       components:
       - name: karavi-authorization-proxy
-        image: dellemc/csm-authorization-sidecar:v1.8.0
+        image: dellemc/csm-authorization-sidecar:v1.9.0
         envs:
           # proxyHost: hostname of the csm-authorization server
           - name: "PROXY_HOST"
@@ -431,10 +431,10 @@ spec:
       #   false: disable Resiliency feature(do not deploy podmon sidecar)
       # Default value: false
       enabled: $OPERATOR_RESILIENCY_ENABLED
-      configVersion: v1.7.0
+      configVersion: v1.8.0
       components:
         - name: podmon-controller
-          image: dellemc/podmon:v1.6.0
+          image: dellemc/podmon:v1.8.0
           imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=$LABEL_VALUE"
@@ -449,7 +449,7 @@ spec:
             - "--driverPath=csi-isilon.dellemc.com"
             - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
         - name: podmon-node
-          image: dellemc/podmon:v1.6.0
+          image: dellemc/podmon:v1.8.0
           imagePullPolicy: IfNotPresent
           envs:
             # podmonAPIPort: Defines the port to be used within the kubernetes cluster

--- a/content/docs/deployment/csminstallationwizard/src/templates/operator/csm-powermax-1.9.0.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/operator/csm-powermax-1.9.0.template
@@ -256,10 +256,10 @@ spec:
     - name: authorization
       # enabled: Enable/Disable csm-authorization
       enabled: $AUTHORIZATION_ENABLED
-      configVersion: v1.8.0
+      configVersion: v1.9.0
       components:
       - name: karavi-authorization-proxy
-        image: dellemc/csm-authorization-sidecar:v1.8.0
+        image: dellemc/csm-authorization-sidecar:v1.9.0
         envs:
           # proxyHost: hostname of the csm-authorization server
           - name: "PROXY_HOST"

--- a/content/docs/deployment/csminstallationwizard/src/templates/operator/csm-powerstore-1.9.0.template
+++ b/content/docs/deployment/csminstallationwizard/src/templates/operator/csm-powerstore-1.9.0.template
@@ -156,10 +156,10 @@ spec:
       #   false: disable Resiliency feature(do not deploy podmon sidecar)
       # Default value: false
       enabled: $OPERATOR_RESILIENCY_ENABLED
-      configVersion: v1.7.0
+      configVersion: v1.8.0
       components:
         - name: podmon-controller
-          image: dellemc/podmon:v1.7.0
+          image: dellemc/podmon:v1.8.0
           imagePullPolicy: IfNotPresent
           args:
             - "--labelvalue=$LABEL_VALUE"
@@ -174,7 +174,7 @@ spec:
             - "--driver-config-params=/powerstore-config-params/driver-config-params.yaml"
             - "--driverPath=csi-powerstore.dellemc.com"
         - name: podmon-node
-          image: dellemc/podmon:v1.7.0
+          image: dellemc/podmon:v1.8.0
           imagePullPolicy: IfNotPresent
           envs:
             # podmonAPIPort: Defines the port to be used within the kubernetes cluster

--- a/content/docs/deployment/csmoperator/_index.md
+++ b/content/docs/deployment/csmoperator/_index.md
@@ -24,16 +24,16 @@ The table below lists the driver and modules versions installable with the CSM O
 
 | CSI Driver         | Version | CSM Authorization | CSM Replication | CSM Observability | CSM Resiliency |
 | ------------------ |---------|-------------------|-----------------|-------------------|----------------|
-| CSI PowerScale     | 2.9.0   | ✔ 1.8.0           | ✔ 1.6.0        | ✔ 1.7.0           | ✔ 1.7.0       |
+| CSI PowerScale     | 2.9.0   | ✔ 1.9.0           | ✔ 1.6.0        | ✔ 1.7.0           | ✔ 1.8.0       |
 | CSI PowerScale     | 2.8.0   | ✔ 1.8.0           | ✔ 1.6.0        | ✔ 1.6.0           | ✔ 1.7.0       |
 | CSI PowerScale     | 2.7.0   | ✔ 1.7.0           | ✔ 1.5.0        | ✔ 1.5.0           | ✔ 1.6.0            |
-| CSI PowerFlex      | 2.9.0   | ✔ 1.8.0           | ✔ 1.6.0        | ✔ 1.7.0           | ✔ 1.7.0       |
+| CSI PowerFlex      | 2.9.0   | ✔ 1.9.0           | ✔ 1.6.0        | ✔ 1.7.0           | ✔ 1.8.0       |
 | CSI PowerFlex      | 2.8.0   | ✔ 1.8.0           | ✔ 1.6.0        | ✔ 1.6.0           | ✔ 1.7.0       |
 | CSI PowerFlex      | 2.7.0   | ✔ 1.7.0           | ✔ 1.5.0        | ✔ 1.5.0           | ✔ 1.6.0       |
-| CSI PowerStore     | 2.9.0   | ❌                | ❌             | ❌                | ✔ 1.7.0       |
+| CSI PowerStore     | 2.9.0   | ❌                | ❌             | ❌                | ✔ 1.8.0       |
 | CSI PowerStore     | 2.8.0   | ❌                | ❌             | ❌                | ✔ 1.7.0       |
 | CSI PowerStore     | 2.7.0   | ❌                | ❌             | ❌                | ✔ 1.6.0       |
-| CSI PowerMax       | 2.9.0   | ✔ 1.8.0           | ✔ 1.6.0        | ✔ 1.7.0           | ❌            |
+| CSI PowerMax       | 2.9.0   | ✔ 1.9.0           | ✔ 1.6.0        | ✔ 1.7.0           | ❌            |
 | CSI PowerMax       | 2.8.0   | ✔ 1.8.0           | ✔ 1.6.0        | ✔ 1.6.0           | ❌            |
 | CSI PowerMax       | 2.7.0   | ✔ 1.7.0           | ✔ 1.5.0        | ❌                | ❌            |
 | CSI Unity XT       | 2.8.0   | ❌                | ❌             | ❌                | ❌            |
@@ -168,7 +168,7 @@ Here is the output of a request to build an offline bundle for the Dell CSM Oper
    dellemc/csi-powerstore:v2.9.0
    dellemc/csi-unity:v2.9.0
    dellemc/csi-vxflexos:v2.9.0
-   dellemc/csm-authorization-sidecar:v1.7.0
+   dellemc/csm-authorization-sidecar:v1.9.0
    dellemc/csm-metrics-powerflex:v1.7.0
    dellemc/csm-metrics-powerscale:v1.4.0
    dellemc/csm-topology:v1.7.0


### PR DESCRIPTION
# Description

Update Authorization and Resiliency to v1.9.0.

Adds missing section for configuring CSI PowerMax with Authorization in the Operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1012 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

