### PR TITLE
[bug-1027]: Clone latest cert-csi tag

### DIFF
--- a/content/docs/csidriver/installation/test/certcsi.md
+++ b/content/docs/csidriver/installation/test/certcsi.md
@@ -70,7 +70,7 @@ mv ./cert-csi-v1.3.0 ~/.local/bin/cert-csi
 1. Clone the repository
 
 ```bash
-git clone https://github.com/dell/cert-csi.git && cd cert-csi
+git clone -b "v1.3.0" https://github.com/dell/cert-csi.git && cd cert-csi
 ```
 
 2. Build cert-csi


### PR DESCRIPTION
# Description

Clone the latest tag of cert-csi instead of main when building locally.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1012 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

