### PR TITLE
Reflect true status of CSI compliance with NFS for PowerMax

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -40,12 +40,12 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Static Provisioning      | yes      | yes       | yes       | yes        | yes        |
 | Dynamic Provisioning     | yes      | yes       | yes       | yes        | yes        |
 | Expand Persistent Volume | yes      | yes       | yes       | yes        | yes        |
-| Create VolumeSnapshot    | yes      | yes       | yes       | yes        | yes        |
-| Create Volume from Snapshot | yes   | yes       | yes       | yes        | yes        |
-| Delete Snapshot          | yes      | yes       | yes       | yes        | yes        |
+| Create VolumeSnapshot    | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
+| Create Volume from Snapshot | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
+| Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
 | Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP |RWO, RWX, ROX, RWOP |Not Supported | RWO, RWX, ROX, RWOP |
-| CSI Volume Cloning       | yes      | yes       | yes       | yes        | yes        |
+| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |
 | Topology                 | yes      | yes       | yes       | yes        | yes        |


### PR DESCRIPTION
# Description
The PowerMax NFS provider does not support a number of standard CSI call, reflecting it in the doc
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

