### PR TITLE
[feature-1091]: Update Authorization Redis storage class and proxy server address information

### DIFF
--- a/content/docs/authorization/Backup and Restore/helm/_index.md
+++ b/content/docs/authorization/Backup and Restore/helm/_index.md
@@ -75,9 +75,9 @@ deployment.apps/proxy-server restarted
 
 ## Tenants, Quota, and Volume ownership
 
-Redis is used to store application data regarding [tenants, quota, and volume ownership](../../design#quota--volume-ownership) with the Storage Class specified in the `redis.storageClass` parameter in the values file, or with the default Storage Class if that parameter was not specified. 
+Redis is used to store application data regarding [tenants, quota, and volume ownership](../../design#quota--volume-ownership) with the Storage Class `csm-authorization-local-storage` or the one specified in the `redis.storageClass` parameter in the values file. 
 
-The Persistent Volume for Redis is dynamically provisioned by this Storage Class with the `redis-primary-pv-claim` Persistent Volume Claim. See the example.
+The Persistent Volume for Redis is provisioned by the above Storage Class with the `redis-primary-pv-claim` Persistent Volume Claim. See the example.
 
 ```bash
 kubectl get persistentvolume

--- a/content/docs/authorization/configuration/powerflex/_index.md
+++ b/content/docs/authorization/configuration/powerflex/_index.md
@@ -108,7 +108,7 @@ Given a setup where Kubernetes, a storage system, and the CSM for Authorization 
     
     - Update `images.authorization` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
 
-    - Update `authorization.proxyHost` to the hostname of the CSM Authorization Proxy Server.
+    - Update `authorization.proxyHost` to the hostname of the CSM Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of CSM for Authorization for the correct value.
     
     - Update `authorization.skipCertificateValidation` to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
 
@@ -144,7 +144,7 @@ Given a setup where Kubernetes, a storage system, and the CSM for Authorization 
 
     - Update the `image` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
 
-    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server.
+    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of CSM for Authorization for the correct value.
 
     - Update the `SKIP_CERTIFICATE_VALIDATION` environment value to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
 

--- a/content/docs/authorization/configuration/powermax/_index.md
+++ b/content/docs/authorization/configuration/powermax/_index.md
@@ -67,7 +67,7 @@ Create the karavi-authorization-config secret using this command:
     
     - Update `images.authorization` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
 
-    - Update `authorization.proxyHost` to the hostname of the CSM Authorization Proxy Server.
+    - Update `authorization.proxyHost` to the hostname of the CSM Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of CSM for Authorization for the correct value.
     
     - Update `authorization.skipCertificateValidation` to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
 
@@ -110,7 +110,7 @@ Create the karavi-authorization-config secret using this command:
 
     - Update the `image` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
 
-    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server.
+    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of CSM for Authorization for the correct value.
 
     - Update the `SKIP_CERTIFICATE_VALIDATION` environment value to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
 

--- a/content/docs/authorization/configuration/powerscale/_index.md
+++ b/content/docs/authorization/configuration/powerscale/_index.md
@@ -116,7 +116,7 @@ kubectl -n isilon create secret generic karavi-authorization-config --from-file=
     
     - Update `images.authorization` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
 
-    - Update `authorization.proxyHost` to the hostname of the CSM Authorization Proxy Server.
+    - Update `authorization.proxyHost` to the hostname of the CSM Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of CSM for Authorization for the correct value.
     
     - Update `authorization.skipCertificateValidation` to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
 
@@ -152,7 +152,7 @@ kubectl -n isilon create secret generic karavi-authorization-config --from-file=
 
     - Update the `image` to the image of the CSM Authorization sidecar. In most cases, you can leave the default value.
 
-    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server.
+    - Update the `PROXY_HOST` environment value to the hostname of the CSM Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of CSM for Authorization for the correct value.
 
     - Update the `SKIP_CERTIFICATE_VALIDATION` environment value to `true` or `false` depending on if you want to disable or enable certificate validation of the CSM Authorization Proxy Server.
 

--- a/content/docs/authorization/configuration/proxy-server/_index.md
+++ b/content/docs/authorization/configuration/proxy-server/_index.md
@@ -14,9 +14,26 @@ The storage administrator must first configure Authorization with the following 
 - Roles
 - Role bindings
 
+The address of the Authorization proxy-server must be specified when executing `karavictl`.
+
+For the `RPM deployment`, the address is the DNS-hostname of the machine where the RPM is installed.
+
+For the `Helm/Operator deployment`, the address is exposed via LoadBalancer/NodePort by the Ingress Controller consuming the proxy-server Ingress. By default, this is the NGINX Ingress Controller.
+
+```
+# kubectl -n authorization get ingress
+NAME           CLASS   HOSTS                                 ADDRESS   PORTS     AGE
+proxy-server   nginx   csm-authorization.com,<other hosts>             80, 443   2m35s
+
+# kubectl -n authorization get service
+NAME                                               TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
+authorization-ingress-nginx-controller             LoadBalancer   10.105.85.204    <pending>     80:30162/TCP,443:32635/TCP   30s
+```
+
+In clusters where there is no integrated LoadBalancer, the `EXTERNAL-IP` field is `<pending>`, so you must use the NodePort address.
+
 >__Note__:
-> - The address of the Authorization proxy-server must be specified when executing `karavictl`. For the `RPM deployment`, the address is the DNS-hostname of the machine where the RPM
-is installed. For the `Helm/Operator deployment`, the address is the Ingress host of the `proxy-server` with the port of the exposed Ingress Controller.
+> - The proxy-server Ingress is configured to resolve by IP address, along with the specified hosts, so you can use a cluster node address such as `<node-ip>:32635`.
 
 ### Configuring Admin Token
 

--- a/content/docs/authorization/deployment/helm/_index.md
+++ b/content/docs/authorization/deployment/helm/_index.md
@@ -89,7 +89,10 @@ The following third-party components are optionally installed in the specified n
 | **redis**           | This section configures Redis.              | -        | -       |
 | redis.images.redis | The image to use for Redis. | Yes | redis:6.0.8-alpine |
 | redis.images.commander | The image to use for Redis Commander. | Yes | rediscommander/redis-commander:latest |
-| redis.storageClass | The storage class for Redis to use for persistence. If not supplied, the default storage class is used. | No | - |
+| redis.storageClass | The storage class for Redis to use for persistence. If not supplied, a locally provisioned volume is used. | No | - |
+
+  >__Note__:  
+  > - If you specify `redis.storageClass`, the storage class must NOT be provisioned by the Dell CSI Driver to be configured with this installation of CSM Authorization.
 
 6. Install the driver using `helm`:
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -60,94 +60,6 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
     kubectl create -f samples/authorization/karavi-storage-secret.yaml
     ```
 
-5. Prepare a storage class for Redis to use for persistence. If not supplied, the default storage class in your environment is used. 
-
-    Example, if using CSM Authorization for PowerScale:
-
-    ```yaml
-      apiVersion: storage.k8s.io/v1
-      kind: StorageClass
-      metadata:
-        name: isilon
-      provisioner: csi-isilon.dellemc.com
-      reclaimPolicy: Delete
-      allowVolumeExpansion: true
-      parameters:
-        # The name of the access zone a volume can be created in
-        # Optional: true
-        # Default value: default value specified in values.yaml
-        # Examples: System, zone1
-        AccessZone: System
-
-        # The base path for the volumes to be created on PowerScale cluster.
-        # Ensure that this path exists on PowerScale cluster.
-        # Allowed values: unix absolute path
-        # Optional: true
-        # Default value: value specified in values.yaml for isiPath
-        # Examples: /ifs/data/csi, /ifs/engineering
-        IsiPath: /ifs/data/csi
-
-        # The permissions for isi volume directory path
-        # This value overrides the isiVolumePathPermissions attribute of corresponding cluster config in secret, if present
-        # Allowed values: valid octal mode number
-        # Default value: "0777"
-        # Examples: "0777", "777", "0755"
-        #IsiVolumePathPermissions: "0777"
-
-        # AccessZone groupnet service IP. Update AzServiceIP if different than endpoint.
-        # Optional: true
-        # Default value: endpoint of the cluster ClusterName
-        #AzServiceIP : 192.168.2.1
-
-        # When a PVC is being created, this parameter determines, when a node mounts the PVC,
-        # whether to add the k8s node to the "Root clients" field or "Clients" field of the NFS export
-        # Allowed values:
-        #   "true": adds k8s node to the "Root clients" field of the NFS export
-        #   "false": adds k8s node to the "Clients" field of the NFS export
-        # Optional: true
-        # Default value: "false"
-        RootClientEnabled: "false"
-
-        # Name of PowerScale cluster, where pv will be provisioned.
-        # This name should match with name of one of the cluster configs in isilon-creds secret.
-        # If this parameter is not specified, then default cluster config in isilon-creds secret
-        # will be considered if available.
-        # Optional: true
-        #ClusterName: <cluster_name>
-
-        # Sets the filesystem type which will be used to format the new volume
-        # Optional: true
-        # Default value: None
-        #csi.storage.k8s.io/fstype: "nfs"
-
-      # volumeBindingMode controls when volume binding and dynamic provisioning should occur.
-      # Allowed values:
-      #   Immediate: indicates that volume binding and dynamic provisioning occurs once the
-      #   PersistentVolumeClaim is created
-      #   WaitForFirstConsumer: will delay the binding and provisioning of a PersistentVolume
-      #   until a Pod using the PersistentVolumeClaim is created
-      # Default value: Immediate
-      volumeBindingMode: Immediate
-
-      # allowedTopologies helps scheduling pods on worker nodes which match all of below expressions.
-      # If enableCustomTopology is set to true in helm values.yaml, then do not specify allowedTopologies
-      # Change all instances of <ISILON_IP> to the IP of the PowerScale OneFS API server
-      #allowedTopologies:
-      #  - matchLabelExpressions:
-      #      - key: csi-isilon.dellemc.com/<ISILON_IP>
-      #        values:
-      #          - csi-isilon.dellemc.com
-
-      # specify additional mount options for when a Persistent Volume is being mounted on a node.
-      # To mount volume with NFSv4, specify mount option vers=4. Make sure NFSv4 is enabled on the Isilon Cluster
-      #mountOptions: ["<mountOption1>", "<mountOption2>", ..., "<mountOptionN>"]
-    ```
-
-    Save the file and create it by using 
-    ```bash
-    kubectl create -f <input_file.yaml>
-    ```
-
 ### Install CSM Authorization Proxy Server
 
 1. Follow all the [prerequisites](#prerequisite).
@@ -162,11 +74,14 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
    | PROXY_HOST | The hostname to configure the self-signed certificate (if applicable), and the proxy service Ingress. | Yes | csm-authorization.com |
    | PROXY_INGRESS_CLASSNAME | The ingressClassName of the proxy-service Ingress. | Yes | nginx |
    | PROXY_INGRESS_HOSTS | Additional host rules to be applied to the proxy-service Ingress.  | No | authorization-ingress-nginx-controller.authorization.svc.cluster.local |
-   | REDIS_STORAGE_CLASS | The storage class for Redis to use for persistence. If not supplied, the default storage class is used. | Yes | - |
+   | REDIS_STORAGE_CLASS | The storage class for Redis to use for persistence. If not supplied, a locally provisioned volume is used. | Yes | - |
    | **ingress-nginx** | This section configures the enablement of the NGINX Ingress Controller. | - | - |
    | enabled | Enable/Disable deployment of the NGINX Ingress Controller. Set to false if you already have an Ingress Controller installed. | No | true |
    | **cert-manager** | This section configures the enablement of cert-manager. | - | - |
    | enabled | Enable/Disable deployment of cert-manager. Set to false if you already have cert-manager installed. | No | true |
+
+  >__Note__:  
+  > - If you specify `REDIS_STORAGE_CLASS`, the storage class must NOT be provisioned by the Dell CSI Driver to be configured with this installation of CSM Authorization.
 
 **Optional:**
 To enable reporting of trace data with [Zipkin](https://zipkin.io/), use the `csm-config-params` configMap in the sample CR or dynamically by editing the configMap.


### PR DESCRIPTION
# Description

For PRs:
https://github.com/dell/helm-charts/pull/353
https://github.com/dell/csm-operator/pull/436

Adds documentation about Authorization installing a locally provisioned volume for Redis by default and the proxy-server being able to be resolved by cluster node IP address.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1091 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

