### PR TITLE
Update resiliency uninstallation instructions

### DIFF
--- a/content/docs/resiliency/uninstallation.md
+++ b/content/docs/resiliency/uninstallation.md
@@ -14,6 +14,6 @@ To uninstall the sidecar in the CSI Driver, the following steps are required.
 
 **Steps**
 1. Uninstall the driver
-    - [Helm uninstallation](../../deployment/helm/drivers/uninstall/#uninstall-a-csi-driver-installed-via-helm)
-    - [Operator uninstallation](../../deployment/csmoperator/drivers/#uninstall-csi-driver)
+    - [Helm](../../deployment/helm/drivers/uninstall/#uninstall-a-csi-driver-installed-via-helm)
+    - [Operator](../../deployment/csmoperator/drivers/#uninstall-csi-driver)
 2. [Reinstall](../../deployment) the driver with the `podmon` feature disabled.

--- a/content/docs/resiliency/uninstallation.md
+++ b/content/docs/resiliency/uninstallation.md
@@ -10,4 +10,10 @@ This section outlines the uninstallation steps for Container Storage Modules (CS
 
 ## Uninstalling the sidecar in the CSI Driver
 
-To uninstall the sidecar in the CSI Driver, [uninstall](../../csidriver/uninstall) the driver and [reinstall](../../deployment) the driver with the `podmon` feature disabled.
+To uninstall the sidecar in the CSI Driver, the following steps are required.
+
+**Steps**
+1. Uninstall the driver
+    - [Helm uninstallation](../../deployment/helm/drivers/uninstall/#uninstall-a-csi-driver-installed-via-helm)
+    - [Operator uninstallation](../../deployment/csmoperator/drivers/#uninstall-csi-driver)
+2. [Reinstall](../../deployment) the driver with the `podmon` feature disabled.


### PR DESCRIPTION
# Description
Updated the resiliency uninstallation instructions to point directly to the uninstallation steps for helm deployments as well as operator deployments.
![image](https://github.com/dell/csm-docs/assets/140824885/3401d1ae-4f9f-4a8b-9b4e-14ef67e3f8dc)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1091|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

