### PR TITLE
Add Vault documentation to Authorization deployment

### DIFF
--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -319,7 +319,7 @@ the Docker host where the server is running.
 vault secrets enable -version=2 -path=csm-authorization/ kv
 ```
 
-Key/Value secret engine is used to store encryption keys. Each encryption key is represented by a key-value entry. 
+Key/Value secret engine is used to store array credentials.
 
 ### Enable Kubernetes authentication
 
@@ -366,6 +366,8 @@ The role needs to be:
 ```shell
 vault kv put -mount=csm-authorization /storage/powerflex/systemid1 username=user password=pass
 ```
+
+The username must use the key `username` and the password must use the key `password`.
 
 ## Token TTL Considerations
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -16,14 +16,16 @@ To deploy the Operator, follow the instructions available [here](../../#installa
 
 ### Prerequisite
 
-1. Execute `kubectl create namespace authorization` to create the authorization namespace (if not already present). Note that the namespace can be any user-defined name, in this example, we assume that the namespace is 'authorization'. 
+1. [Install Vault or configure an existing Vault](#vault-server-installation).
 
-2. Install cert-manager CRDs 
+2. Execute `kubectl create namespace authorization` to create the authorization namespace (if not already present). Note that the namespace can be any user-defined name, in this example, we assume that the namespace is 'authorization'. 
+
+3. Install cert-manager CRDs 
     ```bash
     kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
     ```
 
-3. Prepare [samples/authorization/config.yaml](https://github.com/dell/csm-operator/blob/main/samples/authorization/config.yaml) which contains the JWT signing secret. The following table lists the configuration parameters.
+4. Prepare [samples/authorization/config.yaml](https://github.com/dell/csm-operator/blob/main/samples/authorization/config.yaml) which contains the JWT signing secret. The following table lists the configuration parameters.
 
     | Parameter | Description                                                  | Required | Default |
     | --------- | ------------------------------------------------------------ | -------- | ------- |
@@ -50,7 +52,7 @@ To deploy the Operator, follow the instructions available [here](../../#installa
     kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/authorization/config.yaml -o yaml --dry-run=client | kubectl replace -f -
     ```
 
-4. Create the [karavi-storage-secret](https://github.com/dell/csm-operator/blob/main/samples/authorization/karavi-storage-secret.yaml) to store storage system credentials.
+5. Create the [karavi-storage-secret](https://github.com/dell/csm-operator/blob/main/samples/authorization/karavi-storage-secret.yaml) to store storage system credentials.
 
     Use this command to create the secret:
 

--- a/content/docs/deployment/csmoperator/modules/authorization.md
+++ b/content/docs/deployment/csmoperator/modules/authorization.md
@@ -154,3 +154,226 @@ Follow the instructions available in CSM Authorization for [Configuring a Dell C
 **Authorization v2.0 Technical Preview**
 
 Follow the instructions available in CSM Authorization for [Configuring PowerFlex with Authorization](../../../../authorization/v2.0-tech-preview/configuration/powerflex).
+
+## Vault Server Installation
+
+If there is already a Vault server available, skip to [Minimum Server Configuration](#minimum-server-configuration).
+
+If there is no Vault server available to use with CSM Authorization, it can be installed in many ways following [Hashicorp Vault documentation](https://www.vaultproject.io/docs).
+
+For testing environment, however, a simple deployment suggested in this section may suffice. 
+It creates a standalone server with in-memory (non-persistent) storage, running in a Docker container.
+
+> **NOTE**: With in-memory storage, the data in Vault is permanently destroyed upon the server's termination.
+
+### Generate TLS certificates for server and client
+
+Create server CA private key and certificate:
+
+```shell
+openssl req -x509 -sha256 -days 365 -newkey rsa:2048 -nodes \
+	-subj "/CN=Vault Root CA" \
+	-keyout server-ca.key \
+	-out server-ca.crt
+```
+
+Create server private key and CSR:
+
+```shell
+openssl req -newkey rsa:2048 -nodes \
+	-subj "/CN=vault-demo-server" \
+	-keyout server.key \
+	-out server.csr
+```
+
+Create server certificate signed by the CA:
+
+> Replace `<external IP>` with an IP address by which CSM Authorization can reach the Vault server. 
+This may be the address of the Docker host where the Vault server will be running. 
+
+```shell
+cat > cert.ext <<EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = vault-demo-server
+IP.1 = 127.0.0.1
+IP.2 = <external IP>
+EOF
+
+openssl x509 -req \
+	-CA server-ca.crt -CAkey server-ca.key \
+	-in server.csr \
+	-out server.crt \
+	-days 365 \
+	-extfile cert.ext \
+	-CAcreateserial
+
+cat server-ca.crt >> server.crt
+```
+
+Create client CA private key and certificate:
+
+```shell
+openssl req -x509 -sha256 -days 365 -newkey rsa:2048 -nodes \
+	-subj "/CN=Client Root CA" \
+	-keyout client-ca.key \
+	-out client-ca.crt
+```
+
+Create client private key and CSR:
+
+```shell
+openssl req -newkey rsa:2048 -nodes \
+	-subj "/CN=vault-client" \
+	-keyout client.key \
+	-out client.csr
+```
+
+Create client certificate signed by the CA:
+// todo check ip?
+```shell
+cat > cert.ext <<EOF
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = vault-client
+IP.1 = 127.0.0.1
+EOF
+
+openssl x509 -req \
+	-CA client-ca.crt -CAkey client-ca.key \
+	-in client.csr \
+	-out client.crt \
+	-days 365 \
+	-extfile cert.ext \
+	-CAcreateserial
+
+cat client-ca.crt >> client.crt
+```
+
+### Create server hcl file
+
+```shell
+cat >server.hcl <<EOF
+storage "inmem" {}
+
+listener "tcp" {
+	address = "0.0.0.0:8400"
+	tls_disable = "false"
+	tls_cipher_suites = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+	tls_min_version = "tls12"
+	tls_cert_file = "/var/vault/server.crt"
+	tls_key_file  = "/var/vault/server.key"
+	tls_client_ca_file = "/var/vault/client-ca.crt"
+	tls_require_and_verify_client_cert = "true"
+}
+
+disable_mlock = true
+api_addr = "http://127.0.0.1:8200"
+ui = true
+EOF
+```
+
+### Start Vault Server
+
+> Variable `CONF_DIR` below refers to the directory containing files *server.crt*, *server.key*, *client-ca.crt* and *server.hcl*.
+```shell
+VOL_DIR="$CONF_DIR"
+VOL_DIR_D="/var/vault"
+ROOT_TOKEN="DemoRootToken"
+VAULT_IMG="vault:1.13.3"
+
+docker run --rm -d \
+	--name="vault-server" \
+	-p 8200:8200 -p 8400:8400 \
+	-v $VOL_DIR:$VOL_DIR_D -w $VOL_DIR_D \
+	-e VAULT_DEV_ROOT_TOKEN_ID=$ROOT_TOKEN \
+	-e VAULT_ADDR="http://127.0.0.1:8200" \
+	-e VAULT_TOKEN=$ROOT_TOKEN \
+	$VAULT_IMG \
+	sh -c 'vault server -dev -dev-listen-address 0.0.0.0:8200 -config=server.hcl'
+```
+
+## Minimum Server Configuration
+
+> **NOTE:** this configuration is a bare minimum to support CSM Authorization and is not intended for use in production environment. 
+Refer to the [Hashicorp Vault documentation](https://www.vaultproject.io/docs) for recommended configuration options.
+
+> If a [test instance of Vault](#vault-server-installation) is used, the `vault` commands below can be executed in the Vault server container shell.
+> To enter the shell, run `docker exec -it vault-server sh`. After completing the configuration process, exit the shell by typing `exit`.
+>
+> Alternatively, you can [download the vault binary](https://www.vaultproject.io/downloads) and run it anywhere. 
+> It will require two environment variables to communicate with the Vault server:
+> - `VAULT_ADDR` - URL similar to `http://127.0.0.1:8200`. You may need to change the address in the URL to the address of 
+the Docker host where the server is running.
+> - `VAULT_TOKEN` - Authentication token, e.g. the root token `DemoRootToken` used in the [test instance of Vault](#vault-server-installation).
+
+### Enable Key/Value secret engine
+
+```shell
+vault secrets enable -version=2 -path=csm-authorization/ kv
+```
+
+Key/Value secret engine is used to store encryption keys. Each encryption key is represented by a key-value entry. 
+
+### Enable Kubernetes authentication
+
+```shell
+vault auth enable kubernetes
+```
+
+### Configure Kubernetes authentication
+
+```shell
+vault write auth/kubernetes/config kubernetes_host="$KUBERNETES_HOST" kubernetes_ca_cert="$KUBERNETES_CA_CERT"
+```
+
+### Create a policy
+
+```shell
+vault policy write csm-authorization - <<EOF
+path "csm-authorization/*" {
+	capabilities = ["read"]
+}
+EOF
+```
+The policy needs read access to the path(s) containing the storage credentials.
+
+### Create a role
+
+```shell
+vault write auth/kubernetes/role/csm-authorization \
+	token_ttl=1h \
+	token_max_ttl=1h \
+	token_explicit_max_ttl=10d \
+  bound_service_account_names=storage-service \
+  bound_service_account_namespaces=authorization \
+  policies=csm-authorization
+```
+
+The role needs to be:
+- bound to the `storage-service` service account
+- bound to the namespace where CSM Authorization will be deployed
+- reference the policy that has read access to the storage credentials.
+
+### Write a secret
+
+```shell
+vault kv put -mount=csm-authorization /storage/powerflex/systemid1 username=user password=pass
+```
+
+## Token TTL Considerations
+
+Effective client token TTL is determined by the Vault server based on multiple factors which are described in the [Vault documentation](https://www.vaultproject.io/docs/concepts/tokens#token-time-to-live-periodic-tokens-and-explicit-max-ttls).
+
+With the default server settings, role level values control TTL in this way:
+
+`token_explicit_max_ttl=2h` - limits the client token TTL to 2 hours since it was originally issues as a result of login. This is a hard limit.
+
+`token_ttl=30m` - sets the default client token TTL to 30 minutes. 30 minutes are counted from the login time and from any following token renewal. 
+The client token will only be able to renew 3 times before reaching it total allowed TTL of 2 hours.
+
+Existing role values can be changed using `vault write auth/kubernetes/role/csm-authorization token_ttl=30m token_explicit_max_ttl=2h`.


### PR DESCRIPTION
# Description
Add Vault documentation to Authorization deployment describing how to install a Vault server in a test environment and the configurations required.

Tested by executing each command to setup Vault, install Authorization with the generated client certificates, install Authorization, and create a storage resource.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1281|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

