### PR TITLE
Updated the Authorization RPM deprecation message referencing an invalid version

### DIFF
--- a/content/docs/authorization/Backup and Restore/rpm/_index.md
+++ b/content/docs/authorization/Backup and Restore/rpm/_index.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 ## Roles

--- a/content/docs/authorization/Backup and Restore/rpm/_index.md
+++ b/content/docs/authorization/Backup and Restore/rpm/_index.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in CSM 2.0. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 ## Roles

--- a/content/docs/deployment/rpm/modules/installation/authorization/authorization.md
+++ b/content/docs/deployment/rpm/modules/installation/authorization/authorization.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 This section outlines the deployment steps for Container Storage Modules (CSM) for Authorization.  The deployment of CSM for Authorization is handled in 2 parts:

--- a/content/v1/authorization/Backup and Restore/rpm/_index.md
+++ b/content/v1/authorization/Backup and Restore/rpm/_index.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 ## Roles

--- a/content/v1/authorization/Backup and Restore/rpm/_index.md
+++ b/content/v1/authorization/Backup and Restore/rpm/_index.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in CSM 2.0. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 ## Roles

--- a/content/v1/authorization/deployment/rpm/_index.md
+++ b/content/v1/authorization/deployment/rpm/_index.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 This section outlines the deployment steps for Container Storage Modules (CSM) for Authorization.  The deployment of CSM for Authorization is handled in 2 parts:

--- a/content/v2/authorization/Backup and Restore/rpm/_index.md
+++ b/content/v2/authorization/Backup and Restore/rpm/_index.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 ## Roles

--- a/content/v2/authorization/Backup and Restore/rpm/_index.md
+++ b/content/v2/authorization/Backup and Restore/rpm/_index.md
@@ -6,7 +6,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in CSM 2.0. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 ## Roles

--- a/content/v2/authorization/deployment/rpm/_index.md
+++ b/content/v2/authorization/deployment/rpm/_index.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 {{% pageinfo color="primary" %}}
-The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
+The CSM Authorization RPM is no longer actively maintained or supported. It will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 
 This section outlines the deployment steps for Container Storage Modules (CSM) for Authorization.  The deployment of CSM for Authorization is handled in 2 parts:


### PR DESCRIPTION
# Description
This PR updates the Authorization RPM deprecation message that's been in the documentation since CSM 1.8.  There is some inconsistent messaging in the Backup and Restore/Deployment sections that was fixed as part of this.  One of the messages was referencing CSM 2.0 which is an invalid version.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

