### PR TITLE
Update access mode for Unity

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -24,7 +24,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Create Volume from Snapshot | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
-| Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP |RWO, RWX, ROX, RWOP |Not Supported | RWO, RWX, ROX, RWOP |
+| Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
 | CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |

--- a/content/v1/csidriver/_index.md
+++ b/content/v1/csidriver/_index.md
@@ -43,7 +43,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Create Volume from Snapshot | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
-| Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP |RWO, RWX, ROX, RWOP |Not Supported | RWO, RWX, ROX, RWOP |
+| Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
 | CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |

--- a/content/v2/csidriver/_index.md
+++ b/content/v2/csidriver/_index.md
@@ -43,7 +43,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Create Volume from Snapshot | yes   | yes       | yes       | yes        | yes        |
 | Delete Snapshot          | yes      | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
-| Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP |RWO, RWX, ROX, RWOP |Not Supported | RWO, RWX, ROX, RWOP |
+| Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
 | CSI Volume Cloning       | yes      | yes       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |

--- a/content/v3/csidriver/_index.md
+++ b/content/v3/csidriver/_index.md
@@ -41,7 +41,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Create VolumeSnapshot    | yes      | yes       | yes       | yes        | yes        |
 | Create Volume from Snapshot | yes   | yes       | yes       | yes        | yes        |
 | Delete Snapshot          | yes      | yes       | yes       | yes        | yes        |
-| [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)| **FC/iSCSI:** <br>RWO/<br>RWOP<br> **Raw block:** <br>RWO/<br>RWX/<br>ROX/<br>RWOP | RWO/ROX/RWOP<br><br>RWX (Raw block only) | RWO/ROX/RWOP<br><br>RWX (Raw block & NFS only) | RWO/RWX/ROX/<br>RWOP | RWO/RWOP<br>(FC/iSCSI)<br>RWO/<br>RWX/<br>ROX/<br>RWOP<br>(RawBlock, NFS) |
+| [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)| **FC/iSCSI:** <br>RWO/<br>RWOP<br> **Raw block:** <br>RWO/<br>RWX/<br>ROX/<br>RWOP | RWO/ROX/RWOP<br><br>RWX (Raw block only) | RWO/ROX/RWOP<br><br>RWX (NFS only) <br><br> **Raw block:** <br>RWO/<br>RWX | RWO/RWX/ROX/<br>RWOP | RWO/RWOP<br>(FC/iSCSI)<br>RWO/<br>RWX/<br>ROX/<br>RWOP<br>(RawBlock, NFS) |
 | CSI Volume Cloning       | yes      | yes       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |


### PR DESCRIPTION
# Description
Update Access Mode for `volumeMode: Block` to RWO and RWX for Unity.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1363 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

![image](https://github.com/user-attachments/assets/2c8ee937-47b1-4014-a4ff-a2175b14adbe)


