### PR TITLE
Hide Interactive Tutorials

### DIFF
--- a/content/docs/interactive-tutorials/_index.md
+++ b/content/docs/interactive-tutorials/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Interactive Tutorials"
-linkTitle: "Interactive Tutorials"
+#title: "Interactive Tutorials"
+#linkTitle: "Interactive Tutorials"
 no_list: true
 description: Try CSM and more with interactive labs
 weight: 2
@@ -14,7 +14,6 @@ Our interactive tutorials provide step-by-step guidance on how to use our CSM pr
   If you are new to Dell CSM, start here and use the different modules interactively.
   {{< /card >}}
 {{% /cardpane %}}
-
 
 {{% cardpane %}}
   {{< card header="[**CSM Operator**](csm-operator/)">}}


### PR DESCRIPTION
# Description
Hiding the Instruqt Interactive tutorial as we run out of credits

Can be re-enabled later if need be.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1419 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

