### PR TITLE
Update in home page content for Resiliency and Application Mobility

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -35,7 +35,7 @@ CSM is made up of multiple components including modules (enterprise capabilities
 {{% /cardpane %}}
 {{% cardpane %}}
 {{< card header="[**Resiliency**](resiliency/)"
-          footer="Supports [PowerFlex](csidriver/features/powerflex/) [PowerScale](csidriver/features/powerscale/) [Unity](csidriver/features/unity/) [PowerStore](csidriver/features/powerstore/)">}}
+          footer="Supports [PowerFlex](csidriver/features/powerflex/) [PowerScale](csidriver/features/powerscale/) [Unity](csidriver/features/unity/) [PowerStore](csidriver/features/powerstore/) [PowerFlex](csidriver/features/powerflex/)">}}
   CSM for Resiliency is designed to make Kubernetes Applications, including those that utilize persistent storage, more resilient to various failures.
 [...Learn more](resiliency/)
   {{< /card >}}
@@ -47,7 +47,7 @@ CSM is made up of multiple components including modules (enterprise capabilities
 {{% /cardpane %}}
 {{% cardpane %}}
 {{< card header="[**Application Mobility**](applicationmobility/)"
-          footer="Supports all platforms">}}
+          footer="Supports [PowerFlex](csidriver/features/powerflex/) via Apex Navigator for Kubernetes">}}
   Container Storage Modules for Application Mobility provide Kubernetes administrators the ability to clone their stateful application workloads and application data to other clusters in the cloud.
   [...Learn more](applicationmobility/)
   {{< /card >}}

--- a/content/v1/_index.md
+++ b/content/v1/_index.md
@@ -30,7 +30,7 @@ CSM is made up of multiple components including modules (enterprise capabilities
 {{% /cardpane %}}
 {{% cardpane %}}
 {{< card header="[**Resiliency**](resiliency/)"
-          footer="Supports [PowerFlex](csidriver/features/powerflex/) [PowerScale](csidriver/features/powerscale/) [Unity](csidriver/features/unity/) [PowerStore](csidriver/features/powerstore/)">}}
+          footer="Supports [PowerFlex](csidriver/features/powerflex/) [PowerScale](csidriver/features/powerscale/) [Unity](csidriver/features/unity/) [PowerStore](csidriver/features/powerstore/) [PowerFlex](csidriver/features/powerflex/)">}}
   CSM for Resiliency is designed to make Kubernetes Applications, including those that utilize persistent storage, more resilient to various failures.
 [...Learn more](resiliency/)
   {{< /card >}}
@@ -42,7 +42,7 @@ CSM is made up of multiple components including modules (enterprise capabilities
 {{% /cardpane %}}
 {{% cardpane %}}
 {{< card header="[**Application Mobility**](applicationmobility/)"
-          footer="Supports all platforms">}}
+          footer="Supports [PowerFlex](csidriver/features/powerflex/) via Apex Navigator for Kubernetes">}}
   Container Storage Modules for Application Mobility provide Kubernetes administrators the ability to clone their stateful application workloads and application data to other clusters in the cloud.
   [...Learn more](applicationmobility/)
   {{< /card >}}


### PR DESCRIPTION
# Description
CSM docs home page is not updated. For 1.11(v1) and 1.12(docs) Resiliency supports PowerMax also and Application Mobility supports for only PowerFlex.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1411|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

