### PR TITLE
Rendering Issue of CSM Installation Wizard Page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
      - name: Setup Hugo
        uses: peaceiris/actions-hugo@v2
        with:
-         hugo-version: '0.120.3'
+         hugo-version: '0.134.1'
          extended: true
           
      - name: Setup Go

--- a/content/docs/deployment/csminstallationwizard/src/index.html
+++ b/content/docs/deployment/csminstallationwizard/src/index.html
@@ -16,17 +16,9 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <!-- <header class="fixed-top">
-      <nav class="installation-wizard-navbar">
-        <a href="/csm-docs">
-          <span>
-            <img src="static/images/logo.svg" class="img" alt="Dell Technologies logo">
-          </span>
-        </a>
-      </nav>
-    </header> -->
+   
     <div class="container-fluid pt-5 ">
-      <!-- <main class="container mt-5"> -->
+      
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -727,34 +719,6 @@ disable_footer: true
             <div class="my-3"></div>
           </div>
         </div>
-      <!-- </main> -->
-      <!-- <footer class="py-5 row d-print-none">
-        <div class="container-fluid mx-sm-5">
-          <div class="row">
-            <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
-            <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-              <small class="text-white">&copy; 2024 The Dell Technologies All Rights Reserved</small>
-              <small class="ml-1">
-                <a href="https://www.dell.com/learn/us/en/uscorp1/policies-privacy" target="_blank">Privacy Policy</a>
-              </small>
-            </div>
-            <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3 text-align-right">
-              <ul class="list-inline mb-0">
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="GitHub" data-original-title="GitHub">
-                  <a class="text-white" target="_blank" href="https://github.com/dell/csm">
-                    <svg viewBox="0 0 496 512" height="24"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"  fill="#ffffff"/></svg>
-                  </a>
-                </li>
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Slack" data-original-title="Slack">
-                  <a class="text-white" target="_blank" href="http://del.ly/Slack_request">
-                    <svg viewBox="0 0 448 512" height="24"><path d="M94.12 315.1c0 25.9-21.16 47.06-47.06 47.06S0 341 0 315.1c0-25.9 21.16-47.06 47.06-47.06h47.06v47.06zm23.72 0c0-25.9 21.16-47.06 47.06-47.06s47.06 21.16 47.06 47.06v117.84c0 25.9-21.16 47.06-47.06 47.06s-47.06-21.16-47.06-47.06V315.1zm47.06-188.98c-25.9 0-47.06-21.16-47.06-47.06S139 32 164.9 32s47.06 21.16 47.06 47.06v47.06H164.9zm0 23.72c25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06H47.06C21.16 243.96 0 222.8 0 196.9s21.16-47.06 47.06-47.06H164.9zm188.98 47.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06h-47.06V196.9zm-23.72 0c0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06V79.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06V196.9zM283.1 385.88c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06v-47.06h47.06zm0-23.72c-25.9 0-47.06-21.16-47.06-47.06 0-25.9 21.16-47.06 47.06-47.06h117.84c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06H283.1z" fill="#ffffff"/></svg>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/docs/deployment/csminstallationwizard/src/index.html
+++ b/content/docs/deployment/csminstallationwizard/src/index.html
@@ -16,7 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <header class="fixed-top">
+    <!-- <header class="fixed-top">
       <nav class="installation-wizard-navbar">
         <a href="/csm-docs">
           <span>
@@ -24,9 +24,9 @@ disable_footer: true
           </span>
         </a>
       </nav>
-    </header>
-    <div class="container-fluid pt-5 page-container">
-      <main class="container mt-5">
+    </header> -->
+    <div class="container-fluid pt-5 ">
+      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -727,8 +727,8 @@ disable_footer: true
             <div class="my-3"></div>
           </div>
         </div>
-      </main>
-      <footer class="py-5 row d-print-none">
+      <!-- </main> -->
+      <!-- <footer class="py-5 row d-print-none">
         <div class="container-fluid mx-sm-5">
           <div class="row">
             <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
@@ -754,7 +754,7 @@ disable_footer: true
             </div>
           </div>
         </div>
-      </footer>
+      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/docs/deployment/csminstallationwizard/src/index.html
+++ b/content/docs/deployment/csminstallationwizard/src/index.html
@@ -45,7 +45,7 @@ disable_footer: true
                 </div>
 
                 <div class="was-validated row mb-4">
-                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 140px;">Installation Type</label>
+                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 150px;">Installation Type</label>
                   <div class="col-sm-9"></div>
                   <div class="col-sm-3">
                     <select id="installation-type" class="form-select" onchange="validateInput(validateForm, CONSTANTS);onInstallationTypeChange()" required>

--- a/content/docs/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/docs/deployment/csminstallationwizard/src/static/css/style.css
@@ -148,11 +148,3 @@
   main {
     padding-bottom: 150px;
   }
-
-  /* footer {
-    background-color: #403f4c;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    min-height: 150px;
-  } */

--- a/content/docs/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/docs/deployment/csminstallationwizard/src/static/css/style.css
@@ -149,10 +149,10 @@
     padding-bottom: 150px;
   }
 
-  footer {
+  /* footer {
     background-color: #403f4c;
     position: absolute;
     bottom: 0;
     width: 100%;
     min-height: 150px;
-  }
+  } */

--- a/content/v1/deployment/csminstallationwizard/src/index.html
+++ b/content/v1/deployment/csminstallationwizard/src/index.html
@@ -45,7 +45,7 @@ disable_footer: true
                 </div>
 
                 <div class="was-validated row mb-4">
-                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 140px;">Installation Type</label>
+                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 150px;">Installation Type</label>
                   <div class="col-sm-9"></div>
                   <div class="col-sm-3">
                     <select id="installation-type" class="form-select" onchange="validateInput(validateForm, CONSTANTS);onInstallationTypeChange()" required>

--- a/content/v1/deployment/csminstallationwizard/src/index.html
+++ b/content/v1/deployment/csminstallationwizard/src/index.html
@@ -16,17 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <!-- <header class="fixed-top">
-      <nav class="installation-wizard-navbar">
-        <a href="/csm-docs">
-          <span>
-            <img src="static/images/logo.svg" class="img" alt="Dell Technologies logo">
-          </span>
-        </a>
-      </nav>
-    </header> -->
     <div class="container-fluid pt-5">
-      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -727,34 +717,6 @@ disable_footer: true
             <div class="my-3"></div>
           </div>
         </div>
-      <!-- </main>
-      <footer class="py-5 row d-print-none">
-        <div class="container-fluid mx-sm-5">
-          <div class="row">
-            <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
-            <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-              <small class="text-white">&copy; 2024 The Dell Technologies All Rights Reserved</small>
-              <small class="ml-1">
-                <a href="https://www.dell.com/learn/us/en/uscorp1/policies-privacy" target="_blank">Privacy Policy</a>
-              </small>
-            </div>
-            <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3 text-align-right">
-              <ul class="list-inline mb-0">
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="GitHub" data-original-title="GitHub">
-                  <a class="text-white" target="_blank" href="https://github.com/dell/csm">
-                    <svg viewBox="0 0 496 512" height="24"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"  fill="#ffffff"/></svg>
-                  </a>
-                </li>
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Slack" data-original-title="Slack">
-                  <a class="text-white" target="_blank" href="http://del.ly/Slack_request">
-                    <svg viewBox="0 0 448 512" height="24"><path d="M94.12 315.1c0 25.9-21.16 47.06-47.06 47.06S0 341 0 315.1c0-25.9 21.16-47.06 47.06-47.06h47.06v47.06zm23.72 0c0-25.9 21.16-47.06 47.06-47.06s47.06 21.16 47.06 47.06v117.84c0 25.9-21.16 47.06-47.06 47.06s-47.06-21.16-47.06-47.06V315.1zm47.06-188.98c-25.9 0-47.06-21.16-47.06-47.06S139 32 164.9 32s47.06 21.16 47.06 47.06v47.06H164.9zm0 23.72c25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06H47.06C21.16 243.96 0 222.8 0 196.9s21.16-47.06 47.06-47.06H164.9zm188.98 47.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06h-47.06V196.9zm-23.72 0c0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06V79.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06V196.9zM283.1 385.88c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06v-47.06h47.06zm0-23.72c-25.9 0-47.06-21.16-47.06-47.06 0-25.9 21.16-47.06 47.06-47.06h117.84c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06H283.1z" fill="#ffffff"/></svg>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/v1/deployment/csminstallationwizard/src/index.html
+++ b/content/v1/deployment/csminstallationwizard/src/index.html
@@ -16,7 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <header class="fixed-top">
+    <!-- <header class="fixed-top">
       <nav class="installation-wizard-navbar">
         <a href="/csm-docs">
           <span>
@@ -24,9 +24,9 @@ disable_footer: true
           </span>
         </a>
       </nav>
-    </header>
-    <div class="container-fluid pt-5 page-container">
-      <main class="container mt-5">
+    </header> -->
+    <div class="container-fluid pt-5">
+      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -727,7 +727,7 @@ disable_footer: true
             <div class="my-3"></div>
           </div>
         </div>
-      </main>
+      <!-- </main>
       <footer class="py-5 row d-print-none">
         <div class="container-fluid mx-sm-5">
           <div class="row">
@@ -754,7 +754,7 @@ disable_footer: true
             </div>
           </div>
         </div>
-      </footer>
+      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/v1/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/v1/deployment/csminstallationwizard/src/static/css/style.css
@@ -148,11 +148,3 @@
   main {
     padding-bottom: 150px;
   }
-
-  /* footer {
-    background-color: #403f4c;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    min-height: 150px;
-  } */

--- a/content/v1/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/v1/deployment/csminstallationwizard/src/static/css/style.css
@@ -149,10 +149,10 @@
     padding-bottom: 150px;
   }
 
-  footer {
+  /* footer {
     background-color: #403f4c;
     position: absolute;
     bottom: 0;
     width: 100%;
     min-height: 150px;
-  }
+  } */

--- a/content/v2/deployment/csminstallationwizard/src/index.html
+++ b/content/v2/deployment/csminstallationwizard/src/index.html
@@ -16,17 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <!-- <header class="fixed-top">
-      <nav class="installation-wizard-navbar">
-        <a href="/csm-docs">
-          <span>
-            <img src="static/images/logo.svg" class="img" alt="Dell Technologies logo">
-          </span>
-        </a>
-      </nav>
-    </header> -->
     <div class="container-fluid pt-5">
-      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -726,35 +716,7 @@ disable_footer: true
             </div>
             <div class="my-3"></div>
           </div>
-      <!-- </main> -->
     </div>
-      <!-- <footer class="py-5 row d-print-none">
-        <div class="container-fluid mx-sm-5">
-          <div class="row">
-            <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
-            <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-              <small class="text-white">&copy; 2024 The Dell Technologies All Rights Reserved</small>
-              <small class="ml-1">
-                <a href="https://www.dell.com/learn/us/en/uscorp1/policies-privacy" target="_blank">Privacy Policy</a>
-              </small>
-            </div>
-            <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3 text-align-right">
-              <ul class="list-inline mb-0">
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="GitHub" data-original-title="GitHub">
-                  <a class="text-white" target="_blank" href="https://github.com/dell/csm">
-                    <svg viewBox="0 0 496 512" height="24"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"  fill="#ffffff"/></svg>
-                  </a>
-                </li>
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Slack" data-original-title="Slack">
-                  <a class="text-white" target="_blank" href="http://del.ly/Slack_request">
-                    <svg viewBox="0 0 448 512" height="24"><path d="M94.12 315.1c0 25.9-21.16 47.06-47.06 47.06S0 341 0 315.1c0-25.9 21.16-47.06 47.06-47.06h47.06v47.06zm23.72 0c0-25.9 21.16-47.06 47.06-47.06s47.06 21.16 47.06 47.06v117.84c0 25.9-21.16 47.06-47.06 47.06s-47.06-21.16-47.06-47.06V315.1zm47.06-188.98c-25.9 0-47.06-21.16-47.06-47.06S139 32 164.9 32s47.06 21.16 47.06 47.06v47.06H164.9zm0 23.72c25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06H47.06C21.16 243.96 0 222.8 0 196.9s21.16-47.06 47.06-47.06H164.9zm188.98 47.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06h-47.06V196.9zm-23.72 0c0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06V79.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06V196.9zM283.1 385.88c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06v-47.06h47.06zm0-23.72c-25.9 0-47.06-21.16-47.06-47.06 0-25.9 21.16-47.06 47.06-47.06h117.84c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06H283.1z" fill="#ffffff"/></svg>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/v2/deployment/csminstallationwizard/src/index.html
+++ b/content/v2/deployment/csminstallationwizard/src/index.html
@@ -16,7 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <header class="fixed-top">
+    <!-- <header class="fixed-top">
       <nav class="installation-wizard-navbar">
         <a href="/csm-docs">
           <span>
@@ -24,9 +24,9 @@ disable_footer: true
           </span>
         </a>
       </nav>
-    </header>
-    <div class="container-fluid pt-5 page-container">
-      <main class="container mt-5">
+    </header> -->
+    <div class="container-fluid pt-5">
+      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -726,9 +726,9 @@ disable_footer: true
             </div>
             <div class="my-3"></div>
           </div>
-        </div>
-      </main>
-      <footer class="py-5 row d-print-none">
+      <!-- </main> -->
+    </div>
+      <!-- <footer class="py-5 row d-print-none">
         <div class="container-fluid mx-sm-5">
           <div class="row">
             <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
@@ -754,7 +754,7 @@ disable_footer: true
             </div>
           </div>
         </div>
-      </footer>
+      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/v2/deployment/csminstallationwizard/src/index.html
+++ b/content/v2/deployment/csminstallationwizard/src/index.html
@@ -45,7 +45,7 @@ disable_footer: true
                 </div>
 
                 <div class="was-validated row mb-4">
-                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 140px;">Installation Type</label>
+                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 150px;">Installation Type</label>
                   <div class="col-sm-9"></div>
                   <div class="col-sm-3">
                     <select id="installation-type" class="form-select" onchange="validateInput(validateForm, CONSTANTS);onInstallationTypeChange()" required>

--- a/content/v2/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/v2/deployment/csminstallationwizard/src/static/css/style.css
@@ -149,10 +149,3 @@
     padding-bottom: 150px;
   }
 
-  /* footer {
-    background-color: #403f4c;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    min-height: 150px;
-  } */

--- a/content/v2/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/v2/deployment/csminstallationwizard/src/static/css/style.css
@@ -149,10 +149,10 @@
     padding-bottom: 150px;
   }
 
-  footer {
+  /* footer {
     background-color: #403f4c;
     position: absolute;
     bottom: 0;
     width: 100%;
     min-height: 150px;
-  }
+  } */

--- a/content/v3/deployment/csminstallationwizard/src/index.html
+++ b/content/v3/deployment/csminstallationwizard/src/index.html
@@ -16,7 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <header class="fixed-top">
+    <!-- <header class="fixed-top">
       <nav class="installation-wizard-navbar">
         <a href="/csm-docs">
           <span>
@@ -24,9 +24,9 @@ disable_footer: true
           </span>
         </a>
       </nav>
-    </header>
-    <div class="container-fluid pt-5 page-container">
-      <main class="container mt-5">
+    </header> -->
+    <div class="container-fluid pt-5">
+      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -726,8 +726,8 @@ disable_footer: true
             <div class="my-3"></div>
           </div>
         </div>
-      </main>
-      <footer class="py-5 row d-print-none">
+      <!-- </main> -->
+      <!-- <footer class="py-5 row d-print-none">
         <div class="container-fluid mx-sm-5">
           <div class="row">
             <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
@@ -753,7 +753,7 @@ disable_footer: true
             </div>
           </div>
         </div>
-      </footer>
+      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/v3/deployment/csminstallationwizard/src/index.html
+++ b/content/v3/deployment/csminstallationwizard/src/index.html
@@ -45,7 +45,7 @@ disable_footer: true
                 </div>
 
                 <div class="was-validated row mb-4">
-                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 140px;">Installation Type</label>
+                  <label for="installation-type" class="col-sm-2 col-form-label" data-bs-toggle="tooltip" data-bs-placement="right" title="Select the installation type" style="width: 150px;">Installation Type</label>
                   <div class="col-sm-9"></div>
                   <div class="col-sm-3">
                     <select id="installation-type" class="form-select" onchange="validateInput(validateForm, CONSTANTS);onInstallationTypeChange()" required>

--- a/content/v3/deployment/csminstallationwizard/src/index.html
+++ b/content/v3/deployment/csminstallationwizard/src/index.html
@@ -16,17 +16,7 @@ disable_footer: true
     <script type="text/javascript" src="static/js/bootstrap.bundle.min.js"></script>
   </head>
   <body>
-    <!-- <header class="fixed-top">
-      <nav class="installation-wizard-navbar">
-        <a href="/csm-docs">
-          <span>
-            <img src="static/images/logo.svg" class="img" alt="Dell Technologies logo">
-          </span>
-        </a>
-      </nav>
-    </header> -->
     <div class="container-fluid pt-5">
-      <!-- <main class="container mt-5"> -->
         <div class="row">
           <div class="col-12 pl-md-5">
             <span class="heading">Container Storage Modules (CSM) Installation Wizard </span>
@@ -726,34 +716,6 @@ disable_footer: true
             <div class="my-3"></div>
           </div>
         </div>
-      <!-- </main> -->
-      <!-- <footer class="py-5 row d-print-none">
-        <div class="container-fluid mx-sm-5">
-          <div class="row">
-            <div class="col-6 col-sm-4 text-xs-center order-sm-2"></div>
-            <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-              <small class="text-white">&copy; 2024 The Dell Technologies All Rights Reserved</small>
-              <small class="ml-1">
-                <a href="https://www.dell.com/learn/us/en/uscorp1/policies-privacy" target="_blank">Privacy Policy</a>
-              </small>
-            </div>
-            <div class="col-6 col-sm-4 text-right text-xs-center order-sm-3 text-align-right">
-              <ul class="list-inline mb-0">
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="GitHub" data-original-title="GitHub">
-                  <a class="text-white" target="_blank" href="https://github.com/dell/csm">
-                    <svg viewBox="0 0 496 512" height="24"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"  fill="#ffffff"/></svg>
-                  </a>
-                </li>
-                <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="" aria-label="Slack" data-original-title="Slack">
-                  <a class="text-white" target="_blank" href="http://del.ly/Slack_request">
-                    <svg viewBox="0 0 448 512" height="24"><path d="M94.12 315.1c0 25.9-21.16 47.06-47.06 47.06S0 341 0 315.1c0-25.9 21.16-47.06 47.06-47.06h47.06v47.06zm23.72 0c0-25.9 21.16-47.06 47.06-47.06s47.06 21.16 47.06 47.06v117.84c0 25.9-21.16 47.06-47.06 47.06s-47.06-21.16-47.06-47.06V315.1zm47.06-188.98c-25.9 0-47.06-21.16-47.06-47.06S139 32 164.9 32s47.06 21.16 47.06 47.06v47.06H164.9zm0 23.72c25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06H47.06C21.16 243.96 0 222.8 0 196.9s21.16-47.06 47.06-47.06H164.9zm188.98 47.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06s-21.16 47.06-47.06 47.06h-47.06V196.9zm-23.72 0c0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06V79.06c0-25.9 21.16-47.06 47.06-47.06 25.9 0 47.06 21.16 47.06 47.06V196.9zM283.1 385.88c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06-25.9 0-47.06-21.16-47.06-47.06v-47.06h47.06zm0-23.72c-25.9 0-47.06-21.16-47.06-47.06 0-25.9 21.16-47.06 47.06-47.06h117.84c25.9 0 47.06 21.16 47.06 47.06 0 25.9-21.16 47.06-47.06 47.06H283.1z" fill="#ffffff"/></svg>
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </footer> -->
     </div>
     <script type="text/javascript" src="static/js/constants.js"></script>
     <script type="text/javascript" src="static/js/commands.js"></script>

--- a/content/v3/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/v3/deployment/csminstallationwizard/src/static/css/style.css
@@ -148,11 +148,3 @@
   main {
     padding-bottom: 150px;
   }
-
-  /* footer {
-    background-color: #403f4c;
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    min-height: 150px;
-  } */

--- a/content/v3/deployment/csminstallationwizard/src/static/css/style.css
+++ b/content/v3/deployment/csminstallationwizard/src/static/css/style.css
@@ -149,10 +149,10 @@
     padding-bottom: 150px;
   }
 
-  footer {
+  /* footer {
     background-color: #403f4c;
     position: absolute;
     bottom: 0;
     width: 100%;
     min-height: 150px;
-  }
+  } */


### PR DESCRIPTION
# Description
1) Fixed the rendering issue of the CSM Installation Wizard page for latest version [0.134.1] of Hugo. 
2) The older version [0.120.3] it was working fine but for newer versions from 0.123.0 to latest it was having issues of header and footer. 
3) Upgraded the latest Hugo version in deploy.yaml file in GitHub workflows.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1452|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

