### PR TITLE
Add CSM for Authorization v1 to v2 migration guide

### DIFF
--- a/content/docs/authorization/Migration guide from v1 to v2/_index.md
+++ b/content/docs/authorization/Migration guide from v1 to v2/_index.md
@@ -1,0 +1,179 @@
+---
+title: Authorization - v2 Migration guide
+linktitle: Migration guide from v1 to v2
+weight: 1
+description: >
+  CSM for Authorization v1 to v2 Migration guide
+---
+
+CSM for Authorization v2 has major architectural changes due to which user will not be able to upgrade CSM for Authorization v1 to CSM for Authorization v2. This page provide a referent guide to user **How to migrate** from version 1 to version 2 release.
+
+**Before migration please note following points**
+  - CSM for Authorization v2 calculate the actual usage of capacity provision by syncing with array.
+  - Volumes belong to tenant are identified using **Volume Prefix** configured in tenant CR.
+  - Volumes without **Volume Prefix** will not be accounted in usage capacity calculation as ownership of volume is unknown with the volume prefix.
+  - User should rename all volumes that are needed to be accounted with **Volume Prefix** before migration to v2.
+
+## Storage Systems
+
+In CSM for Authorization v1 setup, list the storage to get all the storages configured in the environment.
+Example: :
+
+```
+karavictl storage list --admin-token admintoken.yaml --addr csm-authorization.host.com
+
+{
+  "storage": {
+    "powerflex": {
+      "3000000000011111": {
+        "Endpoint": "https://1.1.1.1",
+        "Insecure": true,
+        "Password": "(omitted)",
+        "User": "admin"
+      }
+    }
+  }
+}
+```
+In CSM for Authorization v2 storage are created using CRDs, each storage that is created in v1 environment should also be created at v2 environment, here is an example above storage:
+
+```
+kubectl apply/create -f controller/config/samples/csm-authorization_v1_storage.yaml
+```
+Content of csm-authorization_v1_storage.yaml
+```yaml
+apiVersion: csm-authorization.storage.dell.com/v1
+kind: Storage
+metadata:
+name: powerflex
+spec:
+# Type of the storage system. Example: powerflex, powermax, powerscale
+type: powerflex
+endpoint: https://1.1.1.1
+# System ID of the backend storage array
+systemID: 3000000000011111
+# Vault is the credential manager for storage arrays
+vault:
+identifier: vault0
+kvEngine: secret
+path: csm-authorization/powerflex/1a99aa999999aa9a
+# SkipCertificateValidation is the flag to skip certificate validation
+skipCertificateValidation: true
+# PollInterval is the polling frequency to test the storage connectivity
+pollInterval: 30s
+```
+
+
+## Role and Role Binding
+
+In CSM for Authorization v2, role creation is simpler. User will not be required to bind the role, only thing user needs to do is create roles that they needed.
+
+List all the roles that are created in CSM for Authorization v1 setup.
+Example:
+```
+karavictl role list --admin-token admintoken.yaml --addr csm-authorization.host.com
+```
+```
+{
+  "CSIGold": [
+    {
+      "storage_system_id": "3000000000011111",
+      "pool_quotas": [
+        {
+          "pool": "mypool",
+          "quota": 32000000
+        }
+      ]
+    }
+  ],
+  "CSISilver": [
+    {
+      "storage_system_id": "3000000000011111",
+      "pool_quotas": [
+        {
+          "pool": "mypool",
+          "quota": 16000000
+        }
+      ]
+    }
+  ]
+}
+```
+For each role in v1 setup, create roles using csmrole CRD.
+Example
+```
+kubectl apply/create -f controller/config/samples/csm-authorization_v1_csmrole.yaml
+```
+csm-authorization_v1_csmrole.yaml file for **CSIGold** role in v1 setup will look like following example file:
+```yaml
+apiVersion: csm-authorization.storage.dell.com/v1
+kind: CSMRole
+metadata:
+labels:
+app.kubernetes.io/name: role
+app.kubernetes.io/instance: role-sample
+app.kubernetes.io/part-of: csm-authorization
+app.kubernetes.io/managed-by: kustomize
+app.kubernetes.io/created-by: csm-authorization
+name: CSIGold
+spec:
+# The quota must be set with iB (TiB/GiB etc) / Ex. 10 TiB or 512 GiB
+# If it is not, the quota enforcement will be inaccurate
+quota: 1600GiB
+# System ID of the backend storage array
+systemID: 3000000000011111
+# The type of the stoage array. Example: powerflex, powermax, powerscale
+systemType: powerflex
+pool: mypool
+```
+All corresponding v1 setup roles should be created in v2 setup too. In v2 user don't have to bind the role, this will be taken care during CRD reconciliation.
+
+## Tenant
+List all the tenants in v1 setup and all those tenant should be created created in v2 setup.
+List tenants in v1 setup example:
+```
+karavictl tenant list --admin-token admintoken.yaml --addr csm-authorization.host.com
+```
+```
+{
+  "tenants": [
+    {
+      "name": "Alice"
+    }
+  ]
+}
+```
+Get detail of each tenant, example:
+```
+karavictl tenant get --name Alice --admin-token admintoken.yaml --addr csm-authorization.host.com
+```
+```
+{
+  "name": "Alice"
+  "roles": "role-1,role-2"
+}
+```
+Create all v1 setup tenants in v2 setup. Please note that once user create tenant in v2, role binding will be done automatically.
+Example:
+```
+kubectl apply/create -f controller/config/samples/csm-authorization_v1_csmtenant.yaml
+```
+csm-authorization_v1_csmtenant.yaml file will look like following example:
+```yaml
+apiVersion: csm-authorization.storage.dell.com/v1
+kind: CSMTenant
+metadata:
+labels:
+app.kubernetes.io/name: csmtenant
+app.kubernetes.io/instance: csmtenant-sample
+app.kubernetes.io/part-of: csm-authorization
+app.kubernetes.io/managed-by: kustomize
+app.kubernetes.io/created-by: csm-authorization
+name: Alice
+spec:
+# Roles defines a comma separated list of Roles for this tenant
+roles: role-1,role-2
+approveSdc: false
+revoke: false
+volumePrefix: tn1
+```

--- a/content/docs/authorization/Migration guide from v1 to v2/_index.md
+++ b/content/docs/authorization/Migration guide from v1 to v2/_index.md
@@ -6,18 +6,18 @@ description: >
   CSM for Authorization v1 to v2 Migration guide
 ---
 
-CSM for Authorization v2 has significant architectural changes that prevent a user from upgradng CSM for Authorization v1 to CSM for Authorization v2. This page provide a reference guide for migating v1 deployment to v2.
+CSM for Authorization v2 has significant architectural changes that prevent a user from upgradng CSM for Authorization v1 to CSM for Authorization v2. This page provides a reference guide for migrating v1 to v2.
 
 **Before migration please note following points**
-  - CSM for Authorization v2 calculates the actual usage of capacity provisioned by syncing with array.
-  - Volumes belonging to a tenant are identified using **Volume Prefix** configured in tenant CR.
-  - Volumes without **Volume Prefix** will not be accounted in usage capacity calculation as ownership of volume is unknown without the volume prefix.
-  - User should rename all volumes that are needed to be accounted with **Volume Prefix** before migration to v2.
+  - CSM for Authorization v2 calculates the actual usage of capacity provisioned by syncing with the array.
+  - Volumes belonging to a tenant are identified using the **Volume Prefix** configured in csmtenant custom resource.
+  - Volumes without the **Volume Prefix** will not be accounted for in usage capacity calculation as ownership of the volume is unknown without the volume prefix.
+  - User should rename all volumes that are needed to be accounted for with the **Volume Prefix** before migration to v2.
 
 ## Storage Systems
 
 In CSM for Authorization v1 setup, list the storage to get all the storages configured in the environment.
-Example: :
+Example:
 
 ```
 karavictl storage list --admin-token admintoken.yaml --addr csm-authorization.host.com
@@ -35,7 +35,7 @@ karavictl storage list --admin-token admintoken.yaml --addr csm-authorization.ho
   }
 }
 ```
-In CSM for Authorization v2 Storage are created using CRDs. For each Storage in a v1 environment, create using the CRD, example:
+In CSM for Authorization v2 Storage are created using custom resources. For each Storage in a v1 environment, create using the CRD, example:
 
 ```
 kubectl create -f controller/config/samples/csm-authorization_v1_storage.yaml
@@ -65,7 +65,7 @@ spec:
 
 ## Role and Role Binding
 
-In CSM for Authorization v2, role creation is simpler. User will not be required to bind the role, only thing user needs to do is create roles that they needed.
+In CSM for Authorization v2, role creation is simpler. User will not be required to bind the role, only thing user needs to do is create roles that are needed.
 
 List all the roles that are created in CSM for Authorization v1 setup.
 Example:
@@ -98,7 +98,7 @@ karavictl role list --admin-token admintoken.yaml --addr csm-authorization.host.
   ]
 }
 ```
-For each role in v1 setup, create roles using csmrole CRD.
+For each role in v1 setup, create roles using csmrole custom resources.
 Example
 ```
 kubectl create -f controller/config/samples/csm-authorization_v1_csmrole.yaml
@@ -121,7 +121,6 @@ spec:
   systemType: powerflex
   pool: mypool
 ```
-All corresponding v1 setup roles should be created in v2 setup too. In v2 user don't have to bind the role, this will be taken care during CRD reconciliation.
 
 ## Tenant
 

--- a/content/docs/authorization/Migration guide from v1 to v2/_index.md
+++ b/content/docs/authorization/Migration guide from v1 to v2/_index.md
@@ -6,12 +6,12 @@ description: >
   CSM for Authorization v1 to v2 Migration guide
 ---
 
-CSM for Authorization v2 has major architectural changes due to which user will not be able to upgrade CSM for Authorization v1 to CSM for Authorization v2. This page provide a referent guide to user **How to migrate** from version 1 to version 2 release.
+CSM for Authorization v2 has significant architectural changes that prevent a user from upgradng CSM for Authorization v1 to CSM for Authorization v2. This page provide a reference guide for migating v1 deployment to v2.
 
 **Before migration please note following points**
-  - CSM for Authorization v2 calculate the actual usage of capacity provision by syncing with array.
-  - Volumes belong to tenant are identified using **Volume Prefix** configured in tenant CR.
-  - Volumes without **Volume Prefix** will not be accounted in usage capacity calculation as ownership of volume is unknown with the volume prefix.
+  - CSM for Authorization v2 calculates the actual usage of capacity provisioned by syncing with array.
+  - Volumes belonging to a tenant are identified using **Volume Prefix** configured in tenant CR.
+  - Volumes without **Volume Prefix** will not be accounted in usage capacity calculation as ownership of volume is unknown without the volume prefix.
   - User should rename all volumes that are needed to be accounted with **Volume Prefix** before migration to v2.
 
 ## Storage Systems
@@ -35,10 +35,10 @@ karavictl storage list --admin-token admintoken.yaml --addr csm-authorization.ho
   }
 }
 ```
-In CSM for Authorization v2 storage are created using CRDs, each storage that is created in v1 environment should also be created at v2 environment, here is an example above storage:
+In CSM for Authorization v2 Storage are created using CRDs. For each Storage in a v1 environment, create using the CRD, example:
 
 ```
-kubectl apply/create -f controller/config/samples/csm-authorization_v1_storage.yaml
+kubectl create -f controller/config/samples/csm-authorization_v1_storage.yaml
 ```
 Content of csm-authorization_v1_storage.yaml
 ```yaml
@@ -102,7 +102,7 @@ karavictl role list --admin-token admintoken.yaml --addr csm-authorization.host.
 For each role in v1 setup, create roles using csmrole CRD.
 Example
 ```
-kubectl apply/create -f controller/config/samples/csm-authorization_v1_csmrole.yaml
+kubectl create -f controller/config/samples/csm-authorization_v1_csmrole.yaml
 ```
 csm-authorization_v1_csmrole.yaml file for **CSIGold** role in v1 setup will look like following example file:
 ```yaml
@@ -129,7 +129,7 @@ pool: mypool
 All corresponding v1 setup roles should be created in v2 setup too. In v2 user don't have to bind the role, this will be taken care during CRD reconciliation.
 
 ## Tenant
-List all the tenants in v1 setup and all those tenant should be created created in v2 setup.
+List all the tenants in v1 setup and all those tenants should be created in v2 setup.
 List tenants in v1 setup example:
 ```
 karavictl tenant list --admin-token admintoken.yaml --addr csm-authorization.host.com
@@ -153,10 +153,10 @@ karavictl tenant get --name Alice --admin-token admintoken.yaml --addr csm-autho
   "roles": "role-1,role-2"
 }
 ```
-Create all v1 setup tenants in v2 setup. Please note that once user create tenant in v2, role binding will be done automatically.
+For each Tenant in a v1 environment, create a new CSMTenant using the Tenant CRD Role binding will be handled automatically.
 Example:
 ```
-kubectl apply/create -f controller/config/samples/csm-authorization_v1_csmtenant.yaml
+kubectl create -f controller/config/samples/csm-authorization_v1_csmtenant.yaml
 ```
 csm-authorization_v1_csmtenant.yaml file will look like following example:
 ```yaml

--- a/content/docs/authorization/Migration guide from v1 to v2/_index.md
+++ b/content/docs/authorization/Migration guide from v1 to v2/_index.md
@@ -45,24 +45,23 @@ Content of csm-authorization_v1_storage.yaml
 apiVersion: csm-authorization.storage.dell.com/v1
 kind: Storage
 metadata:
-name: powerflex
+  name: powerflex
 spec:
-# Type of the storage system. Example: powerflex, powermax, powerscale
-type: powerflex
-endpoint: https://1.1.1.1
-# System ID of the backend storage array
-systemID: 3000000000011111
-# Vault is the credential manager for storage arrays
-vault:
-identifier: vault0
-kvEngine: secret
-path: csm-authorization/powerflex/1a99aa999999aa9a
-# SkipCertificateValidation is the flag to skip certificate validation
-skipCertificateValidation: true
-# PollInterval is the polling frequency to test the storage connectivity
-pollInterval: 30s
+  # Type of the storage system. Example: powerflex, powermax, powerscale
+  type: powerflex
+  endpoint: https://1.1.1.1
+  # System ID of the backend storage array
+  systemID: 3000000000011111
+  # Vault is the credential manager for storage arrays
+  vault:
+    identifier: vault0
+    kvEngine: secret
+    path: csm-authorization/powerflex/3000000000011111
+  # SkipCertificateValidation is the flag to skip certificate validation
+  skipCertificateValidation: true
+  # PollInterval is the polling frequency to test the storage connectivity
+  pollInterval: 30s
 ```
-
 
 ## Role and Role Binding
 
@@ -109,28 +108,25 @@ csm-authorization_v1_csmrole.yaml file for **CSIGold** role in v1 setup will loo
 apiVersion: csm-authorization.storage.dell.com/v1
 kind: CSMRole
 metadata:
-labels:
-app.kubernetes.io/name: role
-app.kubernetes.io/instance: role-sample
-app.kubernetes.io/part-of: csm-authorization
-app.kubernetes.io/managed-by: kustomize
-app.kubernetes.io/created-by: csm-authorization
-name: CSIGold
+  labels:
+    app.kubernetes.io/name: role
+    app.kubernetes.io/instance: role-sample
+    app.kubernetes.io/part-of: csm-authorization
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: csm-authorization
+  name: CSIGold
 spec:
-# The quota must be set with iB (TiB/GiB etc) / Ex. 10 TiB or 512 GiB
-# If it is not, the quota enforcement will be inaccurate
-quota: 1600GiB
-# System ID of the backend storage array
-systemID: 3000000000011111
-# The type of the stoage array. Example: powerflex, powermax, powerscale
-systemType: powerflex
-pool: mypool
+  quota: 1600GiB
+  systemID: 3000000000011111
+  systemType: powerflex
+  pool: mypool
 ```
 All corresponding v1 setup roles should be created in v2 setup too. In v2 user don't have to bind the role, this will be taken care during CRD reconciliation.
 
 ## Tenant
+
 List all the tenants in v1 setup and all those tenants should be created in v2 setup.
-List tenants in v1 setup example:
+List tenants in v1 setup, example:
 ```
 karavictl tenant list --admin-token admintoken.yaml --addr csm-authorization.host.com
 ```
@@ -153,7 +149,8 @@ karavictl tenant get --name Alice --admin-token admintoken.yaml --addr csm-autho
   "roles": "role-1,role-2"
 }
 ```
-For each Tenant in a v1 environment, create a new CSMTenant using the Tenant CRD Role binding will be handled automatically.
+For each Tenant in a v1 environment, create a new CSMTenant using the Tenant CRD. Role binding will be handled automatically.
+
 Example:
 ```
 kubectl create -f controller/config/samples/csm-authorization_v1_csmtenant.yaml
@@ -163,17 +160,17 @@ csm-authorization_v1_csmtenant.yaml file will look like following example:
 apiVersion: csm-authorization.storage.dell.com/v1
 kind: CSMTenant
 metadata:
-labels:
-app.kubernetes.io/name: csmtenant
-app.kubernetes.io/instance: csmtenant-sample
-app.kubernetes.io/part-of: csm-authorization
-app.kubernetes.io/managed-by: kustomize
-app.kubernetes.io/created-by: csm-authorization
-name: Alice
+  labels:
+    app.kubernetes.io/name: csmtenant
+    app.kubernetes.io/instance: csmtenant-sample
+    app.kubernetes.io/part-of: csm-authorization
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: csm-authorization
+  name: Alice
 spec:
-# Roles defines a comma separated list of Roles for this tenant
-roles: role-1,role-2
-approveSdc: false
-revoke: false
-volumePrefix: tn1
+  # Roles defines a comma separated list of Roles for this tenant
+  roles: role-1,role-2
+  approveSdc: false
+  revoke: false
+  volumePrefix: tn1
 ```

--- a/content/docs/deployment/csmoperator/modules/authorization v2.0 Tech Preview.md
+++ b/content/docs/deployment/csmoperator/modules/authorization v2.0 Tech Preview.md
@@ -18,9 +18,9 @@ To deploy the Operator, follow the instructions available [here](../../#installa
 
 1. [Install Vault or configure an existing Vault](#vault-server-installation).
 
-2. Execute `kubectl create namespace authorization` to create the authorization namespace (if not already present). Note that the namespace can be any user-defined name, in this example, we assume that the namespace is 'authorization'. 
+2. Execute `kubectl create namespace authorization` to create the authorization namespace (if not already present). Note that the namespace can be any user-defined name, in this example, we assume that the namespace is 'authorization'.
 
-3. Install cert-manager CRDs 
+3. Install cert-manager CRDs
     ```bash
     kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
     ```
@@ -39,7 +39,7 @@ To deploy the Operator, follow the instructions available [here](../../#installa
     ```
 
     After editing the file, run this command to create a secret called `karavi-config-secret`:
-    
+
     ```bash
 
     kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/authorization/config.yaml
@@ -48,12 +48,12 @@ To deploy the Operator, follow the instructions available [here](../../#installa
     Use this command to replace or update the secret:
 
     ```bash
-    
+
     kubectl create secret generic karavi-config-secret -n authorization --from-file=config.yaml=samples/authorization/config.yaml -o yaml --dry-run=client | kubectl replace -f -
     ```
 
 
->__Note__:  
+>__Note__:
 > - If you are installing CSM Authorization in a different namespace than `authorization`, edit the `namespace` field in this file to your namespace.
 
 
@@ -98,9 +98,9 @@ To deploy the Operator, follow the instructions available [here](../../#installa
    | privateKey | The base64-encoded private key for the certificate/private-key pair to connect to Vault. Leave empty to use self-signed certificate. | No | - |
    | certificateAuthority | The base64-encoded certificate authority for validating the Vault server. | No | - |
 
->__Note__:  
+>__Note__:
 > - If you are installing CSM Authorization in a different namespace than `authorization`, edit the `namespace` fields in this file to your namespace.
-> - If you specify `storageclass`, the storage class must NOT be provisioned by the Dell CSI Driver to be configured with this installation of CSM Authorization. 
+> - If you specify `storageclass`, the storage class must NOT be provisioned by the Dell CSI Driver to be configured with this installation of CSM Authorization.
 
 **Optional:**
 To enable reporting of trace data with [Zipkin](https://zipkin.io/), use the `csm-config-params` configMap in the sample CR or dynamically by editing the configMap.
@@ -114,11 +114,11 @@ To enable reporting of trace data with [Zipkin](https://zipkin.io/), use the `cs
 4. Execute this command to create the Authorization CR:
 
     ```bash
-    
+
     kubectl create -f <SAMPLE FILE>
     ```
 
-  >__Note__:  
+  >__Note__:
   > - This command will deploy the Authorization Proxy Server in the namespace specified in the input YAML file.
 
 ### Verify Installation of the CSM Authorization Proxy Server
@@ -138,7 +138,7 @@ Follow the instructions available in CSM Authorization for [Configuring the CSM 
 
 ### Configure a Dell CSI Driver with CSM Authorization
 
-Follow the instructions available in CSM Authorization for 
+Follow the instructions available in CSM Authorization for
 - [Configuring PowerFlex with Authorization](../../../../authorization/v2.0-tech-preview/configuration/powerflex).
 - [Configuring PowerMax with Authorization](../../../../authorization/v2.0-tech-preview/configuration/powermax).
 
@@ -148,7 +148,7 @@ If there is already a Vault server available, skip to [Minimum Server Configurat
 
 If there is no Vault server available to use with CSM Authorization, it can be installed in many ways following [Hashicorp Vault documentation](https://www.vaultproject.io/docs).
 
-For testing environment, however, a simple deployment suggested in this section may suffice. 
+For testing environment, however, a simple deployment suggested in this section may suffice.
 It creates a standalone server with in-memory (non-persistent) storage, running in a Docker container.
 
 > **NOTE**: With in-memory storage, the data in Vault is permanently destroyed upon the server's termination.
@@ -175,8 +175,8 @@ openssl req -newkey rsa:2048 -nodes \
 
 Create server certificate signed by the CA:
 
-> Replace `<external IP>` with an IP address by which CSM Authorization can reach the Vault server. 
-This may be the address of the Docker host where the Vault server will be running. 
+> Replace `<external IP>` with an IP address by which CSM Authorization can reach the Vault server.
+This may be the address of the Docker host where the Vault server will be running.
 
 ```shell
 cat > cert.ext <<EOF
@@ -219,7 +219,6 @@ openssl req -newkey rsa:2048 -nodes \
 ```
 
 Create client certificate signed by the CA:
-// todo check ip?
 ```shell
 cat > cert.ext <<EOF
 authorityKeyIdentifier=keyid,issuer
@@ -286,15 +285,15 @@ docker run --rm -d \
 
 ## Minimum Server Configuration
 
-> **NOTE:** this configuration is a bare minimum to support CSM Authorization and is not intended for use in production environment. 
+> **NOTE:** this configuration is a bare minimum to support CSM Authorization and is not intended for use in production environment.
 Refer to the [Hashicorp Vault documentation](https://www.vaultproject.io/docs) for recommended configuration options.
 
 > If a [test instance of Vault](#vault-server-installation) is used, the `vault` commands below can be executed in the Vault server container shell.
 > To enter the shell, run `docker exec -it vault-server sh`. After completing the configuration process, exit the shell by typing `exit`.
 >
-> Alternatively, you can [download the vault binary](https://www.vaultproject.io/downloads) and run it anywhere. 
+> Alternatively, you can [download the vault binary](https://www.vaultproject.io/downloads) and run it anywhere.
 > It will require two environment variables to communicate with the Vault server:
-> - `VAULT_ADDR` - URL similar to `http://127.0.0.1:8200`. You may need to change the address in the URL to the address of 
+> - `VAULT_ADDR` - URL similar to `http://127.0.0.1:8200`. You may need to change the address in the URL to the address of
 the Docker host where the server is running.
 > - `VAULT_TOKEN` - Authentication token, e.g. the root token `DemoRootToken` used in the [test instance of Vault](#vault-server-installation).
 
@@ -362,7 +361,7 @@ With the default server settings, role level values control TTL in this way:
 
 `token_explicit_max_ttl=2h` - limits the client token TTL to 2 hours since it was originally issues as a result of login. This is a hard limit.
 
-`token_ttl=30m` - sets the default client token TTL to 30 minutes. 30 minutes are counted from the login time and from any following token renewal. 
+`token_ttl=30m` - sets the default client token TTL to 30 minutes. 30 minutes are counted from the login time and from any following token renewal.
 The client token will only be able to renew 3 times before reaching it total allowed TTL of 2 hours.
 
 Existing role values can be changed using `vault write auth/kubernetes/role/csm-authorization token_ttl=30m token_explicit_max_ttl=2h`.


### PR DESCRIPTION
# Description
CSM for Authorization v2 is not backward compatible. This steps will guide existing CSM for Authorization v1 users how to migrate to v2.

![image](https://github.com/user-attachments/assets/9bc4929f-25b5-416a-a5c1-ba43893a7e9e)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| #https://github.com/dell/csm/issues/1281 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

