### PR TITLE
Call reusable action for go version updates

### DIFF
--- a/.github/workflows/go-version.yaml
+++ b/.github/workflows/go-version.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Reusable workflow to perform go version update on Golang based projects
+name: Go Version Update
+
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [go-update-workflow]
+
+jobs:
+  # go version update
+  go-version-update:
+    uses: dell/common-github-actions/.github/workflows/go-version-workflow.yaml@main
+    name: Go Version Update
+    secrets: inherit


### PR DESCRIPTION
# Description
Add caller workflow Go Version Update. It can be manually triggered or it can be triggered by [Trigger Go Version Workflow](https://github.com/dell/common-github-actions/actions/workflows/trigger-go-workflow.yaml).

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1490|


# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

