### PR TITLE
Powerflex capability matrix change

### DIFF
--- a/content/docs/csidriver/_index.md
+++ b/content/docs/csidriver/_index.md
@@ -25,7 +25,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
 | Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
-| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
+| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes for LUN<br>no for NFS       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |
 | Topology                 | yes      | yes       | yes       | yes        | yes        |

--- a/content/v1/csidriver/_index.md
+++ b/content/v1/csidriver/_index.md
@@ -25,7 +25,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
 | Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
-| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
+| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes for LUN<br>no for NFS        | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |
 | Topology                 | yes      | yes       | yes       | yes        | yes        |

--- a/content/v2/csidriver/_index.md
+++ b/content/v2/csidriver/_index.md
@@ -25,7 +25,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
 | Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
-| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
+| CSI Volume Cloning       | yes for LUN<br>no for NFS       |yes for LUN<br>no for NFS       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |
 | Topology                 | yes      | yes       | yes       | yes        | yes        |

--- a/content/v2/csidriver/_index.md
+++ b/content/v2/csidriver/_index.md
@@ -25,7 +25,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
 | Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
-| CSI Volume Cloning       | yes for LUN<br>no for NFS       |yes for LUN<br>no for NFS       | yes       | yes        | yes        |
+| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes for LUN<br>no for NFS       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |
 | Topology                 | yes      | yes       | yes       | yes        | yes        |

--- a/content/v3/csidriver/_index.md
+++ b/content/v3/csidriver/_index.md
@@ -44,7 +44,7 @@ The CSI Drivers by Dell implement an interface between [CSI](https://kubernetes-
 | Delete Snapshot          | yes for LUN<br>no for NFS | yes       | yes       | yes        | yes        |
 | [Access Mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) for [volumeMode: Filesystem](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#volume-mode)| RWO, RWOP<br><br>ROX, RWX **with NFS ONLY**| RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, ROX, RWOP<br><br>RWX  **with NFS ONLY** | RWO, RWX, ROX, RWOP | RWO, RWOP<br><br>ROX, RWX **with NFS ONLY** |
 | Access Mode for `volumeMode: Block`| RWO, RWX, ROX, RWOP | RWO, RWX, ROX, RWOP | RWO, RWX | Not Supported | RWO, RWX, ROX, RWOP |
-| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes       | yes       | yes        | yes        |
+| CSI Volume Cloning       | yes for LUN<br>no for NFS       | yes for LUN<br>no for NFS       | yes       | yes        | yes        |
 | CSI Raw Block Volume     | yes      | yes       | yes       | no         | yes        |
 | CSI Ephemeral Volume     | no       | yes       | yes       | yes        | yes        |
 | Topology                 | yes      | yes       | yes       | yes        | yes        |


### PR DESCRIPTION
# Description
Update Powerflex Driver Capabilities in CSM docs that CSI Volume Cloning is not supported for nfs in Powerflex

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1498|

# Checklist:

- [X] Have you run a grammar and spell checks against your submission?
- [X] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?
![image](https://github.com/user-attachments/assets/7fa5faaa-0360-410e-89d8-c9ef5bc4e63c)

