### PR TITLE
Add deprecation notice for Volume Group Snapshotter

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -10,6 +10,8 @@ no_list: true
 ---
 
 {{% pageinfo color="primary" %}}
+DELL CSM Volume Group Snapshotter will be deprecated in CSM 1.14 (May 2025) and will no longer be supported.
+
 The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -10,7 +10,7 @@ no_list: true
 ---
 
 {{% pageinfo color="primary" %}}
-DELL CSM Volume Group Snapshotter will be deprecated in CSM 1.14 (May 2025) and will no longer be supported.
+Dell CSM Volume Group Snapshotter will be deprecated in CSM 1.14 (May 2025) and will no longer be supported.
 
 The CSM Authorization RPM will be deprecated in a future release. It is highly recommended that you use CSM Authorization Helm deployment or CSM Operator going forward.
 {{% /pageinfo %}}

--- a/content/docs/snapshots/volume-group-snapshots/_index.md
+++ b/content/docs/snapshots/volume-group-snapshots/_index.md
@@ -5,6 +5,10 @@ weight: 8
 Description: >
   Volume Group Snapshot module of Dell CSI drivers
 ---
+
+{{% pageinfo color="primary" %}} DELL CSM Volume Group Snapshotter will be deprecated in CSM 1.14 (May 2025) and will no longer be supported. 
+{{% /pageinfo %}}
+
 ## Volume Group Snapshot Feature
 The Dell CSM Volume Group Snapshotter is an operator which extends Kubernetes API to support crash-consistent snapshots of groups of volumes.
 Volume Group Snapshot supports PowerFlex and PowerStore driver.

--- a/content/docs/snapshots/volume-group-snapshots/_index.md
+++ b/content/docs/snapshots/volume-group-snapshots/_index.md
@@ -6,7 +6,7 @@ Description: >
   Volume Group Snapshot module of Dell CSI drivers
 ---
 
-{{% pageinfo color="primary" %}} DELL CSM Volume Group Snapshotter will be deprecated in CSM 1.14 (May 2025) and will no longer be supported. 
+{{% pageinfo color="primary" %}} Dell CSM Volume Group Snapshotter will be deprecated in CSM 1.14 (May 2025) and will no longer be supported. 
 {{% /pageinfo %}}
 
 ## Volume Group Snapshot Feature


### PR DESCRIPTION
# Description
This PR adds notices to indicate that Volume Group Snapshotter will be deprecated in CSM 1.14 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1544|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

