### PR TITLE
Usr/lukeatdell/powerstore secret update

### DIFF
--- a/content/docs/csidriver/features/powerstore.md
+++ b/content/docs/csidriver/features/powerstore.md
@@ -538,16 +538,19 @@ After that, you can use `powerstore-1` storage class to create volumes on the fi
 
 ## Dynamic secret change detection
 
-CSI PowerStore driver version 1.3.0 and later supports the ability to detect changes to array configuration Kubernetes secret. This essentially means that you can change credentials for your PowerStore arrays in-flight (without restarting the driver).
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
 
-To do so just change your configuration file `config.yaml` and apply it again using the following command:
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
 ```bash
 
 sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
 ```
 
-After Kubernetes remounts secret to driver containers (this usually takes around one minute), a driver must detect the change and start using this new configuration information.
-
+After Kubernetes remounts the secret to the driver containers (this usually takes around one minute), the driver will detect the change and start using
+the new configuration information.
 
 ## Configuring custom access to NFS exports
 

--- a/content/docs/deployment/csmoperator/drivers/powerstore.md
+++ b/content/docs/deployment/csmoperator/drivers/powerstore.md
@@ -10,7 +10,7 @@ To deploy the Operator, follow the instructions available [here](../../#installa
 
 Note that the deployment of the driver using the operator does not use any Helm charts and the installation and configuration parameters will be slightly different from the one specified via the Helm installer.
 
-### Listing installed drivers
+## Listing installed drivers
 
 To query for all Dell CSI drivers installed with the ContainerStorageModule CRD use the following command:
 
@@ -322,7 +322,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
    sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
    ```
 
-### Install Driver
+## Install Driver
 
 1. Follow all the [prerequisites](#prerequisites) above
 

--- a/content/docs/deployment/csmoperator/drivers/powerstore.md
+++ b/content/docs/deployment/csmoperator/drivers/powerstore.md
@@ -371,3 +371,16 @@ CRDs should be configured during replication prepare stage with repctl as descri
 **Note** :
    1. "Kubelet config dir path" is not yet configurable in case of Operator based driver installation.
    2. Snapshotter and resizer sidecars are not optional. They are defaults with Driver installation.
+
+## Dynamic secret change detection
+
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
+```bash
+
+sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
+```

--- a/content/docs/deployment/helm/drivers/installation/powerstore.md
+++ b/content/docs/deployment/helm/drivers/installation/powerstore.md
@@ -429,14 +429,17 @@ There are samples storage class yaml files available under `samples/storageclass
 
 ## Volume Snapshot Class
 
-Starting CSI PowerStore v1.4.0, `dell-csi-helm-installer` will not create any Volume Snapshot Class during the driver installation. There is a sample Volume Snapshot Class manifest present in the _samples/volumesnapshotclass_ folder. Please use this sample to create a new Volume Snapshot Class to create Volume Snapshots.
+Starting with CSI PowerStore v1.4.0, `dell-csi-helm-installer` will not create any Volume Snapshot Class during the driver installation. There is a sample Volume Snapshot Class manifest present in the _samples/volumesnapshotclass_ folder. Please use this sample to create a new Volume Snapshot Class to create Volume Snapshots.
 
 ## Dynamically update the powerstore secrets
 
-Users can dynamically add delete array information from secret. Whenever an update happens the driver updates the “Host” information in an array. User can update secret using the following command:
+Users can dynamically modify array information within the secret. Whenever an update happens the driver updates the “Host” information in an array. User can update the secret using the following commands:
 ```bash
 kubectl create secret generic powerstore-config -n csi-powerstore --from-file=config=secret.yaml -o yaml --dry-run=client | kubectl replace -f -
+kubectl rollout restart daemonset -n csi-powerstore
 ```
+>Note: The driver's node pods must be restarted to apply any changes made to the secret. This is achieved using the `kubectl rollout restart` command above.
+
 ## Dynamic Logging Configuration
 
 This feature is introduced in CSI Driver for PowerStore version 2.0.0.

--- a/content/docs/deployment/helm/drivers/installation/powerstore.md
+++ b/content/docs/deployment/helm/drivers/installation/powerstore.md
@@ -433,12 +433,15 @@ Starting with CSI PowerStore v1.4.0, `dell-csi-helm-installer` will not create a
 
 ## Dynamically update the powerstore secrets
 
-Users can dynamically modify array information within the secret. Whenever an update happens the driver updates the “Host” information in an array. User can update the secret using the following commands:
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+User can update the secret using the following commands:
 ```bash
 kubectl create secret generic powerstore-config -n csi-powerstore --from-file=config=secret.yaml -o yaml --dry-run=client | kubectl replace -f -
-kubectl rollout restart daemonset -n csi-powerstore
 ```
->Note: The driver's node pods must be restarted to apply any changes made to the secret. This is achieved using the `kubectl rollout restart` command above.
 
 ## Dynamic Logging Configuration
 

--- a/content/v1/csidriver/features/powerstore.md
+++ b/content/v1/csidriver/features/powerstore.md
@@ -533,18 +533,21 @@ kubectl create -f storageclass.yaml
 
 After that, you can use `powerstore-1` storage class to create volumes on the first array and `powerstore-2` storage class to create volumes on the second array. 
 
-## Dynamic secret change detection 
+## Dynamic secret change detection
 
-CSI PowerStore driver version 1.3.0 and later supports the ability to detect changes to array configuration Kubernetes secret. This essentially means that you can change credentials for your PowerStore arrays in-flight (without restarting the driver). 
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
 
-To do so just change your configuration file `config.yaml` and apply it again using the following command:
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
 ```bash
 
 sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
 ```
 
-After Kubernetes remounts secret to driver containers (this usually takes around one minute), a driver must detect the change and start using this new configuration information. 
-
+After Kubernetes remounts the secret to the driver containers (this usually takes around one minute), the driver will detect the change and start using
+the new configuration information.
 
 ## Configuring custom access to NFS exports
 

--- a/content/v1/deployment/csmoperator/drivers/powerstore.md
+++ b/content/v1/deployment/csmoperator/drivers/powerstore.md
@@ -357,3 +357,16 @@ CRDs should be configured during replication prepare stage with repctl as descri
 **Note** :
    1. "Kubelet config dir path" is not yet configurable in case of Operator based driver installation.
    2. Snapshotter and resizer sidecars are not optional. They are defaults with Driver installation.
+
+## Dynamic secret change detection
+
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
+```bash
+
+sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
+```

--- a/content/v1/deployment/helm/drivers/installation/powerstore.md
+++ b/content/v1/deployment/helm/drivers/installation/powerstore.md
@@ -421,10 +421,16 @@ Starting CSI PowerStore v1.4.0, `dell-csi-helm-installer` will not create any Vo
 
 ## Dynamically update the powerstore secrets
 
-Users can dynamically add delete array information from secret. Whenever an update happens the driver updates the “Host” information in an array. User can update secret using the following command:
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+User can update the secret using the following commands:
 ```bash
 kubectl create secret generic powerstore-config -n csi-powerstore --from-file=config=secret.yaml -o yaml --dry-run=client | kubectl replace -f -
 ```
+
 ## Dynamic Logging Configuration
 
 This feature is introduced in CSI Driver for PowerStore version 2.0.0.

--- a/content/v2/csidriver/features/powerstore.md
+++ b/content/v2/csidriver/features/powerstore.md
@@ -533,18 +533,21 @@ kubectl create -f storageclass.yaml
 
 After that, you can use `powerstore-1` storage class to create volumes on the first array and `powerstore-2` storage class to create volumes on the second array. 
 
-## Dynamic secret change detection 
+## Dynamic secret change detection
 
-CSI PowerStore driver version 1.3.0 and later supports the ability to detect changes to array configuration Kubernetes secret. This essentially means that you can change credentials for your PowerStore arrays in-flight (without restarting the driver). 
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
 
-To do so just change your configuration file `config.yaml` and apply it again using the following command:
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
 ```bash
 
 sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
 ```
 
-After Kubernetes remounts secret to driver containers (this usually takes around one minute), a driver must detect the change and start using this new configuration information. 
-
+After Kubernetes remounts the secret to the driver containers (this usually takes around one minute), the driver will detect the change and start using
+the new configuration information.
 
 ## Configuring custom access to NFS exports
 

--- a/content/v2/deployment/csmoperator/drivers/powerstore.md
+++ b/content/v2/deployment/csmoperator/drivers/powerstore.md
@@ -357,3 +357,16 @@ CRDs should be configured during replication prepare stage with repctl as descri
 **Note** :
    1. "Kubelet config dir path" is not yet configurable in case of Operator based driver installation.
    2. Snapshotter and resizer sidecars are not optional. They are defaults with Driver installation.
+
+## Dynamic secret change detection
+
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
+```bash
+
+sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
+```

--- a/content/v2/deployment/helm/drivers/installation/powerstore.md
+++ b/content/v2/deployment/helm/drivers/installation/powerstore.md
@@ -421,10 +421,16 @@ Starting CSI PowerStore v1.4.0, `dell-csi-helm-installer` will not create any Vo
 
 ## Dynamically update the powerstore secrets
 
-Users can dynamically add delete array information from secret. Whenever an update happens the driver updates the “Host” information in an array. User can update secret using the following command:
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+User can update the secret using the following commands:
 ```bash
 kubectl create secret generic powerstore-config -n csi-powerstore --from-file=config=secret.yaml -o yaml --dry-run=client | kubectl replace -f -
 ```
+
 ## Dynamic Logging Configuration
 
 This feature is introduced in CSI Driver for PowerStore version 2.0.0.

--- a/content/v3/csidriver/features/powerstore.md
+++ b/content/v3/csidriver/features/powerstore.md
@@ -533,18 +533,21 @@ kubectl create -f storageclass.yaml
 
 After that, you can use `powerstore-1` storage class to create volumes on the first array and `powerstore-2` storage class to create volumes on the second array. 
 
-## Dynamic secret change detection 
+## Dynamic secret change detection
 
-CSI PowerStore driver version 1.3.0 and later supports the ability to detect changes to array configuration Kubernetes secret. This essentially means that you can change credentials for your PowerStore arrays in-flight (without restarting the driver). 
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
 
-To do so just change your configuration file `config.yaml` and apply it again using the following command:
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
 ```bash
 
 sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
 ```
 
-After Kubernetes remounts secret to driver containers (this usually takes around one minute), a driver must detect the change and start using this new configuration information. 
-
+After Kubernetes remounts the secret to the driver containers (this usually takes around one minute), the driver will detect the change and start using
+the new configuration information.
 
 ## Configuring custom access to NFS exports
 

--- a/content/v3/csidriver/installation/helm/powerstore.md
+++ b/content/v3/csidriver/installation/helm/powerstore.md
@@ -421,10 +421,16 @@ Starting CSI PowerStore v1.4.0, `dell-csi-helm-installer` will not create any Vo
 
 ## Dynamically update the powerstore secrets
 
-Users can dynamically add delete array information from secret. Whenever an update happens the driver updates the “Host” information in an array. User can update secret using the following command:
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+User can update the secret using the following commands:
 ```bash
 kubectl create secret generic powerstore-config -n csi-powerstore --from-file=config=secret.yaml -o yaml --dry-run=client | kubectl replace -f -
 ```
+
 ## Dynamic Logging Configuration
 
 This feature is introduced in CSI Driver for PowerStore version 2.0.0.

--- a/content/v3/deployment/csmoperator/drivers/powerstore.md
+++ b/content/v3/deployment/csmoperator/drivers/powerstore.md
@@ -357,3 +357,16 @@ CRDs should be configured during replication prepare stage with repctl as descri
 **Note** :
    1. "Kubelet config dir path" is not yet configurable in case of Operator based driver installation.
    2. Snapshotter and resizer sidecars are not optional. They are defaults with Driver installation.
+
+## Dynamic secret change detection
+
+CSI PowerStore supports the ability to dynamically modify array information within the secret, allowing users to update
+<u>_credentials_</u> for the PowerStore arrays, in-flight, without restarting the driver.
+> Note: Updates to the secret that include adding a new array, or modifying the endpoint, globalID, or blockProtocol parameters
+> require the driver to be restarted to properly pick up and process the changes.
+
+To do so, change the configuration file `config.yaml` and apply the update using the following command:
+```bash
+
+sed "s/CONFIG_YAML/`cat config.yaml | base64 -w0`/g" secret.yaml | kubectl apply -f -
+```


### PR DESCRIPTION
# Description
Clarifying parameters supported by the dynamic secret update functionality in CSI PowerStore.
User must restart the driver if any updates are made to `endpoint`, `globalID`, or `blockProtocol`, or if a new array is added to the secret.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1538 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] ~Have you added high-resolution images?~
