### PR TITLE
CapacityTracking suite docs update

### DIFF
--- a/content/docs/support/cert-csi/_index.md
+++ b/content/docs/support/cert-csi/_index.md
@@ -155,7 +155,7 @@ storageClasses:
       volumeAttributes: # volume attrs for EphemeralVolumeSuite.
         attr1: # volume attr for EphemeralVolumeSuite
         attr2: # volume attr for EphemeralVolumeSuite
-    capacityTracking:
+    capacityTracking: # capacityTracking test requires the storage class to have volume binding mode as 'WaitForFirstConsumer'
       driverNamespace: # namepsace where driver is installed
       pollInterval:    # duration to poll capacity (e.g., 2m)
 ```
@@ -223,7 +223,9 @@ storageClasses:
         IsiPath: "/ifs/data/sample"
         IsiVolumePathPermissions: "0777"
         AzServiceIP: "192.168.2.1"
-
+    capacityTracking:
+      driverNamespace: isilon
+      pollInterval: 2m
    {{</tab >}}
    {{<tab header="CSI PowerMax" >}}
 

--- a/content/v1/support/cert-csi/_index.md
+++ b/content/v1/support/cert-csi/_index.md
@@ -159,7 +159,7 @@ storageClasses:
       volumeAttributes: # volume attrs for EphemeralVolumeSuite.
         attr1: # volume attr for EphemeralVolumeSuite
         attr2: # volume attr for EphemeralVolumeSuite
-    capacityTracking:
+    capacityTracking: # capacityTracking test requires the storage class to have volume binding mode as 'WaitForFirstConsumer'
       driverNamespace: # namepsace where driver is installed
       pollInterval:    # duration to poll capacity (e.g., 2m)  
 ```
@@ -227,7 +227,9 @@ storageClasses:
         IsiPath: "/ifs/data/sample"
         IsiVolumePathPermissions: "0777"
         AzServiceIP: "192.168.2.1"
-
+    capacityTracking:
+      driverNamespace: isilon
+      pollInterval: 2m
    {{</tab >}}
    {{<tab header="CSI PowerMax" >}}
 

--- a/content/v2/support/cert-csi/_index.md
+++ b/content/v2/support/cert-csi/_index.md
@@ -166,7 +166,7 @@ storageClasses:
       volumeAttributes: # volume attrs for EphemeralVolumeSuite.
         attr1: # volume attr for EphemeralVolumeSuite
         attr2: # volume attr for EphemeralVolumeSuite
-    capacityTracking:
+    capacityTracking: # capacityTracking test requires the storage class to have volume binding mode as 'WaitForFirstConsumer'
       driverNamespace: # namepsace where driver is installed
       pollInterval:    # duration to poll capacity (e.g., 2m)  
 ```
@@ -234,7 +234,9 @@ storageClasses:
         IsiPath: "/ifs/data/sample"
         IsiVolumePathPermissions: "0777"
         AzServiceIP: "192.168.2.1"
-
+    capacityTracking:
+      driverNamespace: isilon
+      pollInterval: 2m
 
    {{</tab >}}
    {{<tab header="CSI PowerMax" >}}

--- a/content/v3/csidriver/installation/test/certcsi.md
+++ b/content/v3/csidriver/installation/test/certcsi.md
@@ -151,7 +151,7 @@ storageClasses:
       volumeAttributes: # volume attrs for EphemeralVolumeSuite.
         attr1: # volume attr for EphemeralVolumeSuite
         attr2: # volume attr for EphemeralVolumeSuite
-    capacityTracking:
+    capacityTracking: # capacityTracking test requires the storage class to have volume binding mode as 'WaitForFirstConsumer'
       driverNamespace: # namepsace where driver is installed
       pollInterval:    # duration to poll capacity (e.g., 2m)  
 ```
@@ -218,7 +218,9 @@ storageClasses:
         IsiPath: "/ifs/data/sample"
         IsiVolumePathPermissions: "0777"
         AzServiceIP: "192.168.2.1"
-
+    capacityTracking:
+      driverNamespace: isilon
+      pollInterval: 2m
    {{< /tab >}}
    {{< tab header="CSI PowerMax" >}}
 


### PR DESCRIPTION
# Description
This PR adds the missing `capacityTracking` test section in the certify config YAML example for CSI-PowerScale driver and adds a note for the requirement of volume binding mode to be set as `WaitForFirstConsumer`

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1503 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

