### PR TITLE
Remove the prerequisite of multiple secrets which is not necessary with the same cert and key

### DIFF
--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -50,7 +50,6 @@ Use a tool such as `openssl` to generate this secret using the example below:
 ```bash
 openssl genrsa -out tls.key 2048
 openssl req -new -x509 -sha256 -key tls.key -out tls.crt -days 3650
-kubectl create secret -n <namespace> tls revproxy-certs --cert=tls.crt --key=tls.key
 kubectl create secret -n <namespace> tls csirevproxy-tls-secret --cert=tls.crt --key=tls.key
 ```
 

--- a/content/v1/deployment/csmoperator/drivers/powermax.md
+++ b/content/v1/deployment/csmoperator/drivers/powermax.md
@@ -219,7 +219,6 @@ Use a tool such as `openssl` to generate this secret using the example below:
 ```bash
 openssl genrsa -out tls.key 2048
 openssl req -new -x509 -sha256 -key tls.key -out tls.crt -days 3650
-kubectl create secret -n <namespace> tls revproxy-certs --cert=tls.crt --key=tls.key
 kubectl create secret -n <namespace> tls csirevproxy-tls-secret --cert=tls.crt --key=tls.key
 ```
 

--- a/content/v2/deployment/csmoperator/drivers/powermax.md
+++ b/content/v2/deployment/csmoperator/drivers/powermax.md
@@ -197,7 +197,6 @@ Use a tool such as `openssl` to generate this secret using the example below:
 ```bash
 openssl genrsa -out tls.key 2048
 openssl req -new -x509 -sha256 -key tls.key -out tls.crt -days 3650
-kubectl create secret -n <namespace> tls revproxy-certs --cert=tls.crt --key=tls.key
 kubectl create secret -n <namespace> tls csirevproxy-tls-secret --cert=tls.crt --key=tls.key
 ```
 

--- a/content/v3/deployment/csmoperator/drivers/powermax.md
+++ b/content/v3/deployment/csmoperator/drivers/powermax.md
@@ -197,7 +197,6 @@ Use a tool such as `openssl` to generate this secret using the example below:
 ```bash
 openssl genrsa -out tls.key 2048
 openssl req -new -x509 -sha256 -key tls.key -out tls.crt -days 3650
-kubectl create secret -n <namespace> tls revproxy-certs --cert=tls.crt --key=tls.key
 kubectl create secret -n <namespace> tls csirevproxy-tls-secret --cert=tls.crt --key=tls.key
 ```
 


### PR DESCRIPTION
# Description
Removed the prerequisite of multiple secrets which is not necessary with the same cert and key for PowerMax driver in CSM-docs all versions.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|dell/csm#1557 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

