### PR TITLE
Remove reference to APEX Navigator for Kubernetes

### DIFF
--- a/content/docs/deployment/csmoperator/_index.md
+++ b/content/docs/deployment/csmoperator/_index.md
@@ -438,5 +438,3 @@ The specification for the Custom Resource is the same for all the drivers.Below 
 **nodeSelector** - Used to specify node selectors for the driver StatefulSet/Deployment and DaemonSet.
 
 >NOTE: The `image` field should point to the correct image tag for version of the driver you are installing.
-
->NOTE: The CSM Operator 1.6 is pre-requisite for onboarding brownfield clusters with Apex Navigator For Kubernetes. When the Dell connectivity client is installed, a role and rolebinding will be established in the namespace containing CSM objects, and these will be removed when the client is uninstalled. If the client is already present in the cluster and CSM is deployed or deleted, the roles and rolebindings will be correspondingly created or removed during CSM reconciliation. This process ensures that the client can access the secrets in the namespace.


### PR DESCRIPTION
# Description
Remove reference to APEX Navigator for Kubernetes in the CSM Operator documentation.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1572 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

