### PR TITLE
Update CSI-PowerMax ReverseProxy Configmap Sample

### DIFF
--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -353,14 +353,14 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
           primaryURL: https://primary-1.unisphe.re:8443 # primary unisphere for arrayID
           backupURL: https://backup-1.unisphe.re:8443   # backup unisphere for arrayID
           proxyCredentialSecrets:
-            - proxy-secret-11 # credential secret for primary unisphere, e.g., powermax-creds
-            - proxy-secret-12 # credential secret for backup unisphere, e.g., powermax-creds
+            - primary-1-secret # credential secret for primary unisphere, e.g., powermax-creds
+            - backup-1-secret # credential secret for backup unisphere, e.g., powermax-creds
         - storageArrayId: "000000000002"
           primaryURL: https://primary-2.unisphe.re:8443
           backupURL: https://backup-2.unisphe.re:8443
           proxyCredentialSecrets:
-           - proxy-secret-21
-           - proxy-secret-22
+           - primary-2-secret
+           - backup-2-secret
      managementServers:
        - url: https://primary-1.unisphe.re:8443 # primary unisphere endpoint
          arrayCredentialSecret: primary-1-secret # primary credential secret e.g., powermax-creds

--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -353,27 +353,27 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
           primaryURL: https://primary-1.unisphe.re:8443 # primary unisphere for arrayID
           backupURL: https://backup-1.unisphe.re:8443   # backup unisphere for arrayID
           proxyCredentialSecrets:
-            - primary-1-secret # credential secret for primary unisphere, e.g., powermax-creds
-            - backup-1-secret # credential secret for backup unisphere, e.g., powermax-creds
+            - primary-unisphere-secret-1 # credential secret for primary unisphere, e.g., powermax-creds
+            - backup-unisphere-secret-1 # credential secret for backup unisphere, e.g., powermax-creds
         - storageArrayId: "000000000002"
           primaryURL: https://primary-2.unisphe.re:8443
           backupURL: https://backup-2.unisphe.re:8443
           proxyCredentialSecrets:
-           - primary-2-secret
-           - backup-2-secret
+           - primary-unisphere-secret-2
+           - backup-unisphere-secret-2
      managementServers:
        - url: https://primary-1.unisphe.re:8443 # primary unisphere endpoint
-         arrayCredentialSecret: primary-1-secret # primary credential secret e.g., powermax-creds
+         arrayCredentialSecret: primary-unisphere-secret-1 # primary credential secret e.g., powermax-creds
          skipCertificateValidation: true
        - url: https://backup-1.unisphe.re:8443 # backup unisphere endpoint
-         arrayCredentialSecret: backup-1-secret # backup credential secret e.g., powermax-creds
+         arrayCredentialSecret: backup-unisphere-secret-1 # backup credential secret e.g., powermax-creds
          skipCertificateValidation: false # value false, to verify unisphere certificate and provide certSecret
          certSecret: primary-certs # unisphere verification certificate
        - url: https://primary-2.unisphe.re:8443
-         arrayCredentialSecret: primary-2-secret
+         arrayCredentialSecret: primary-unisphere-secret-2
          skipCertificateValidation: true
        - url: https://backup-2.unisphe.re:8443
-         arrayCredentialSecret: backup-2-secret
+         arrayCredentialSecret: backup-unisphere-secret-2
          skipCertificateValidation: false
          certSecret: primary-certs
    ```

--- a/content/docs/deployment/helm/drivers/installation/powermax.md
+++ b/content/docs/deployment/helm/drivers/installation/powermax.md
@@ -351,7 +351,7 @@ CRDs should be configured during replication prepare stage with repctl as descri
 | backupEndpoint | This refers to the URL of the backup Unisphere server managing _storageArrayId_, if Reverse Proxy is installed in _StandAlone_ mode. If authorization is enabled, backupEndpoint should be the HTTPS localhost endpoint that the authorization sidecar will listen on                                                                                                           | Yes | https://backup-1.unisphe.re:8443 |
 | managementServers | This section refers to the list of configurations for Unisphere servers managing powermax arrays.                                                                                                                                                                                                                                                                               | - | - |
 | endpoint | This refers to the URL of the Unisphere server. If authorization is enabled, endpoint should be the HTTPS localhost endpoint that the authorization sidecar will listen on                                                                                                                                                                                                      | Yes | https://primary-1.unisphe.re:8443 |
-| credentialsSecret| This refers to the user credentials for _endpoint_                                                                                                                                                                                                                                                                                                                              | Yes| primary-1-secret|
+| credentialsSecret| This refers to the user credentials for _endpoint_                                                                                                                                                                                                                                                                                                                              | Yes| primary-unisphere-secret-1|
 | skipCertificateValidation | This parameter should be set to false if you want to do client-side TLS verification of Unisphere for PowerMax SSL certificates.                                                                                                                                                                                                                                                | No | "True"       |
 | certSecret    | The name of the secret in the same namespace containing the CA certificates of the Unisphere server                                                                                                                                                                                                                                                                             | Yes, if skipCertificateValidation is set to false | Empty|
 | limits | This refers to various limits for Reverse Proxy                                                                                                                                                                                                                                                                                                                                 | No | - |
@@ -472,7 +472,7 @@ global:
       backupEndpoint: https://backup-2.unisphe.re:8443
   managementServers:
     - endpoint: https://primary-1.unisphe.re:8443
-      credentialsSecret: primary-1-secret
+      credentialsSecret: primary-unisphere-secret-1
       skipCertificateValidation: false
       certSecret: primary-cert
       limits:
@@ -481,13 +481,13 @@ global:
         maxOutStandingRead: 50
         maxOutStandingWrite: 50
     - endpoint: https://backup-1.unisphe.re:8443
-      credentialsSecret: backup-1-secret
+      credentialsSecret: backup-unisphere-secret-1
       skipCertificateValidation: true
     - endpoint: https://primary-2.unisphe.re:8443
-      credentialsSecret: primary-2-secret
+      credentialsSecret: primary-unisphere-secret-2
       skipCertificateValidation: true
     - endpoint: https://backup-2.unisphe.re:8443
-      credentialsSecret: backup-2-secret
+      credentialsSecret: backup-unisphere-secret-2
       skipCertificateValidation: true
 
 # "csireverseproxy" refers to the subchart csireverseproxy


### PR DESCRIPTION
# Description
The sample configmap for the csi-powermax reverseproxy had ambiguous secret names -- that is being fixed [here](https://github.com/dell/csi-powermax/pull/366), and this PR makes an accompanying doc change.
# GitHub Issues
| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1568 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add examples wherever applicable?
- [ ] Have you added high-resolution images?

