### PR TITLE
Add note covering non unique host NQNs on OCP.

### DIFF
--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -113,9 +113,9 @@ modprobe nvme_tcp
 
 **Cluster requirments**
 
-- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NVMe Qualified Names (NQNs).
 
-> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+> The OpenShift deployment process for CoreOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
 
 ```yaml
 apiVersion: machineconfiguration.openshift.io/v1

--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -127,7 +127,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     systemd:
       units:
         - contents: |

--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -114,6 +114,37 @@ modprobe nvme_tcp
 **Cluster requirments**
 
 - All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+
+> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-custom-nvme-hostnqn
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Custom CoreOS Generate NVMe Hostnqn
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/bin/sh -c '/usr/sbin/nvme gen-hostnqn > /etc/nvme/hostnqn'
+            RemainAfterExit=yes
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: custom-coreos-generate-nvme-hostnqn.service
+```
+
 - The driver requires the NVMe command-line interface (nvme-cli) to manage the NVMe clients and targets. The NVMe CLI tool is installed in the host using the following command on RPM oriented Linux distributions.
 
 ```bash
@@ -408,7 +439,7 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
           # Choose which transport protocol to use (ISCSI, FC, NVMETCP, auto) defaults to auto if nothing is specified
           X_CSI_TRANSPORT_PROTOCOL: ""
           # IP address of the Unisphere for PowerMax (Required), Defaults to https://0.0.0.0:8443
-          X_CSI_POWERMAX_ENDPOINT: "https://10.0.0.0:8443" 
+          X_CSI_POWERMAX_ENDPOINT: "https://10.0.0.0:8443"
           # List of comma-separated array ID(s) which will be managed by the driver (Required)
           X_CSI_MANAGED_ARRAYS: "000000000000,000000000000,"
    ```

--- a/content/docs/deployment/csmoperator/drivers/powerstore.md
+++ b/content/docs/deployment/csmoperator/drivers/powerstore.md
@@ -95,7 +95,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     systemd:
       units:
         - contents: |

--- a/content/docs/deployment/csmoperator/drivers/powerstore.md
+++ b/content/docs/deployment/csmoperator/drivers/powerstore.md
@@ -81,9 +81,9 @@ Refer to the [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault
 
 The following requirements must be fulfilled in order to successfully use the NVMe protocols with the CSI PowerStore driver:
 
-- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NVMe Qualified Names (NQNs).
 
-> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+> The OpenShift deployment process for CoreOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
 
 ```yaml
 apiVersion: machineconfiguration.openshift.io/v1

--- a/content/docs/deployment/csmoperator/drivers/powerstore.md
+++ b/content/docs/deployment/csmoperator/drivers/powerstore.md
@@ -82,6 +82,37 @@ Refer to the [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault
 The following requirements must be fulfilled in order to successfully use the NVMe protocols with the CSI PowerStore driver:
 
 - All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+
+> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-custom-nvme-hostnqn
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Custom CoreOS Generate NVMe Hostnqn
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/bin/sh -c '/usr/sbin/nvme gen-hostnqn > /etc/nvme/hostnqn'
+            RemainAfterExit=yes
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: custom-coreos-generate-nvme-hostnqn.service
+```
+
 - The driver requires the NVMe command-line interface (nvme-cli) to manage the NVMe clients and targets. The NVMe CLI tool is installed in the host using the following command on RPM oriented Linux distributions.
 
 ```bash

--- a/content/docs/deployment/helm/drivers/installation/powermax.md
+++ b/content/docs/deployment/helm/drivers/installation/powermax.md
@@ -198,7 +198,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     storage:
       files:
       - contents:

--- a/content/docs/deployment/helm/drivers/installation/powermax.md
+++ b/content/docs/deployment/helm/drivers/installation/powermax.md
@@ -117,10 +117,40 @@ modprobe nvme_tcp
 
 > Starting with OCP 4.14 NVMe/TCP is enabled by default on RCOS nodes.
 
-
 **Cluster requirments**
 
 - All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+
+> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+
+```yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-custom-nvme-hostnqn
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Custom CoreOS Generate NVMe Hostnqn
+
+            [Service]
+            Type=oneshot
+            ExecStart=/usr/bin/sh -c '/usr/sbin/nvme gen-hostnqn > /etc/nvme/hostnqn'
+            RemainAfterExit=yes
+
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: custom-coreos-generate-nvme-hostnqn.service
+```
+
 - The driver requires the NVMe command-line interface (nvme-cli) to manage the NVMe clients and targets. The NVMe CLI tool is installed in the host using the following command on RPM oriented Linux distributions.
 
 ```bash

--- a/content/docs/deployment/helm/drivers/installation/powermax.md
+++ b/content/docs/deployment/helm/drivers/installation/powermax.md
@@ -119,9 +119,9 @@ modprobe nvme_tcp
 
 **Cluster requirments**
 
-- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NVMe Qualified Names (NQNs).
 
-> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+> The OpenShift deployment process for CoreOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
 
 ```yaml
 apiVersion: machineconfiguration.openshift.io/v1

--- a/content/docs/deployment/helm/drivers/installation/powerstore.md
+++ b/content/docs/deployment/helm/drivers/installation/powerstore.md
@@ -84,9 +84,9 @@ Refer to the [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault
 
 The following requirements must be fulfilled in order to successfully use the NVMe protocols with the CSI PowerStore driver:
 
-- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NQNs.
+- All OpenShift or Kubernetes nodes connecting to Dell storage arrays must use unique host NVMe Qualified Names (NQNs).
 
-> The OpenShift deployment process for RHCOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
+> The OpenShift deployment process for CoreOS will set the same host NQN for all nodes. The host NQN is stored in the file /etc/nvme/hostnqn. One possible solution to ensure unique host NQNs is to add the following machine config to your OCP cluster:
 
 ```yaml
 apiVersion: machineconfiguration.openshift.io/v1

--- a/content/docs/deployment/helm/drivers/installation/powerstore.md
+++ b/content/docs/deployment/helm/drivers/installation/powerstore.md
@@ -98,7 +98,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.4.0
     systemd:
       units:
         - contents: |


### PR DESCRIPTION
# Description
Per user feedback we added notes for resolving duplicated host NQNs for OCP nodes. The addition of a machine config to the OCP cluster will generate a unique host NQN for each node.

![image](https://github.com/user-attachments/assets/da6ac880-fdcf-43ff-bc0b-33f14af2fcb3)


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1643 |

# Checklist:

- [X] Have you run a grammar and spell checks against your submission?
- [X] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [X] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

Tested config on an OCP cluster and validated that the configuration was applied to each node and unique NQNs were generated. Noteworthy that the NQNs remained the same (but still unique) after node reboot.
