### PR TITLE
Add PowerMax Mount Credentials for installation with Operator

### DIFF
--- a/content/docs/csidriver/features/powermax.md
+++ b/content/docs/csidriver/features/powermax.md
@@ -692,6 +692,11 @@ managementServers:
     username: admin
     password: password
     skipCertificateValidation: true
+    limits:
+      maxActiveRead: 5
+      maxActiveWrite: 4
+      maxOutStandingRead: 50
+      maxOutStandingWrite: 50
   - endpoint: https://backup-1.unisphe.re:8443
     username: admin2
     password: password2

--- a/content/docs/csidriver/features/powermax.md
+++ b/content/docs/csidriver/features/powermax.md
@@ -696,6 +696,7 @@ managementServers:
     username: admin2
     password: password2
     skipCertificateValidation: false
+    certSecret: primary-cert
 ```
 
 This method works with both `helm` and `operator` installations for PowerMax, automatically mounting the secret for use by the PowerMax driver/node and the Reverse Proxy.

--- a/content/docs/csidriver/features/powermax.md
+++ b/content/docs/csidriver/features/powermax.md
@@ -678,3 +678,26 @@ These are the CSM modules not supported with NVMeTCP protocol:
 - CSM Observability
 - CSM Application Mobility
 - Metro Replication
+
+## Mount Credentials Support
+
+The CSI Driver for Dell PowerMax supports Mount Credentials from v2.14.0 and the configMap will be deprecated. In previous versions of the PowerMax Reverse Proxy, in order to configure it, a config map needed to be created and the credentials for the arrays would be stored in secrets which the config map would reference. To simplify this solution, a mountable secret can be used which contains the array information and credentials all in one location.
+```yaml
+storageArrays:
+  - storageArrayId: "000000000001"
+    primaryEndpoint: https://primary-1.unisphe.re:8443
+    backupEndpoint: https://backup-1.unisphe.re:8443
+managementServers:
+  - endpoint: https://primary-1.unisphe.re:8443
+    username: admin
+    password: password
+    skipCertificateValidation: true
+  - endpoint: https://backup-1.unisphe.re:8443
+    username: admin2
+    password: password2
+    skipCertificateValidation: false
+```
+
+This approach is supported in both `helm` and `operator` installation for PowerMax. Both installation will automatically mount the secret to be used by the PowerMax driver/node and the Reverse Proxy.
+
+**Note:** The config map approach is being deprecated but to adhere to backwards compatibility, one can still configure and use the PowerMax driver with the config map.

--- a/content/docs/csidriver/features/powermax.md
+++ b/content/docs/csidriver/features/powermax.md
@@ -681,7 +681,7 @@ These are the CSM modules not supported with NVMeTCP protocol:
 
 ## Mount Credentials Support
 
-The CSI Driver for Dell PowerMax supports Mount Credentials from v2.14.0 and the configMap will be deprecated. In previous versions of the PowerMax Reverse Proxy, in order to configure it, a config map needed to be created and the credentials for the arrays would be stored in secrets which the config map would reference. To simplify this solution, a mountable secret can be used which contains the array information and credentials all in one location.
+From version 2.14.0, the CSI Driver for Dell PowerMax supports Mount Credentials, making the configMap obsolete. In earlier versions of the PowerMax Reverse Proxy, configuring it required creating a config map that referenced credentials stored in secrets. Now, a single mountable secret can be used to store both array information and credentials, simplifying the setup.
 ```yaml
 storageArrays:
   - storageArrayId: "000000000001"
@@ -698,6 +698,6 @@ managementServers:
     skipCertificateValidation: false
 ```
 
-This approach is supported in both `helm` and `operator` installation for PowerMax. Both installation will automatically mount the secret to be used by the PowerMax driver/node and the Reverse Proxy.
+This method works with both `helm` and `operator` installations for PowerMax, automatically mounting the secret for use by the PowerMax driver/node and the Reverse Proxy.
 
-**Note:** The config map approach is being deprecated but to adhere to backwards compatibility, one can still configure and use the PowerMax driver with the config map.
+**Note:** The config map approach is being phased out. However, for backwards compatibility, you can still configure and use the PowerMax driver with the config map.

--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -5,9 +5,9 @@ description: >
   Installing the CSI Driver for Dell PowerMax via Dell CSM Operator
 ---
 {{% pageinfo color="primary" %}}
-1. <span></span>{{< message text="1" >}}
+1. <span></span>{{< message text="11" >}}
 
-2. <span></span>{{< message text="11" >}}
+2. <span></span>{{< message text="1" >}}
 {{% /pageinfo %}}
 The CSI Driver for Dell PowerMax can be installed via the Dell CSM Operator.
 To deploy the Operator, follow the instructions available [here](../../#installation).
@@ -371,9 +371,9 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
 
 1. Create a namespace in which the driver will be installed.
    ```bash
-   kubectl create namespace <driver-namespace>
+   kubectl create namespace powermax
    ```
-2. Create the `powermax-reverseproxy-secret` secret.
+2. Create the `powermax-creds` secret.
 
     - *storageArrays*: A list of storage arrays and their associated details.
       - *storageArrayId*: A unique PowerMax Symmetrix ID.
@@ -400,9 +400,9 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
         password: password2
         skipCertificateValidation: false
     ```
-    After editing the file, run this command to create a secret called `powermax-reverseproxy-config`. If you are using a different namespace/secret name, just substitute those into the command.
+    After editing the file, run this command to create a secret called `powermax-creds`. If you are using a different namespace/secret name, just substitute those into the command.
     ```bash
-    kubectl create secret generic powermax-reverseproxy-secret --namespace powermax --from-file=config=samples/secret/secret.yaml
+    kubectl create secret generic powermax-creds --namespace powermax --from-file=config=samples/secret/secret.yaml
     ```
 4. Create a configmap using the sample file [here](https://github.com/dell/csi-powermax/blob/main/samples/configmap/powermax-array-config.yaml). Fill in the appropriate values for driver configuration.
    ```yaml
@@ -479,7 +479,7 @@ Example:
    | X_CSI_VSPHERE_PORTGROUP                         | Existing portGroup that driver will use for vSphere                                                                                                                                                                                                                      | Yes      | ""                             |
    | X_CSI_VSPHERE_HOSTNAME                          | Existing host(initiator group)/host group(cascaded initiator group) that driver will use for vSphere                                                                                                                                                                     | Yes      | ""                             |
    | X_CSI_VCenter_HOST                              | URL/endpoint of the vCenter where all the ESX are present                                                                                                                                                                                                                | Yes      | ""                             |
-   | X_CSI_REVPROXY_USE_SECRET | Define whether or not to use the new secret format for the PowerMax and the Reverse Proxy. The secret used will be whatever secret is defined in the `authSecret`. **Note:** If this paramter remains `false`, PowerMax and the reverse proxy will use the configMap approach. | Yes      | "false" |
+   | X_CSI_REVPROXY_USE_SECRET | Define whether or not to use the new secret format for the PowerMax and the Reverse Proxy. The secret format will be determined by the contents of the secret specified in the `authSecret`. **Note:** If this paramter remains `false`, PowerMax and the reverse proxy will use the configMap approach. | Yes      | "false" |
    | ***Node parameters***                           |                                                                                                                                                                                                                                                                          |          |                                |
    | X_CSI_POWERMAX_ISCSI_ENABLE_CHAP                | Enable ISCSI CHAP authentication. For more details on this feature see the related [documentation](../../../../csidriver/features/powermax/#iscsi-chap)                                                                                                                               | No       | false                          |
    | X_CSI_TOPOLOGY_CONTROL_ENABLED                  | Enable/Disabe topology control. It filters out arrays, associated transport protocol available to each node and creates topology keys based on any such user input.                                                                                                      | No       | false                          |

--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -399,6 +399,7 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
         username: admin2
         password: password2
         skipCertificateValidation: false
+        certSecret: primary-cert
     ```
     After editing the file, run this command to create a secret called `powermax-creds`. If you are using a different namespace/secret name, just substitute those into the command.
     ```bash

--- a/content/docs/deployment/csmoperator/drivers/powermax.md
+++ b/content/docs/deployment/csmoperator/drivers/powermax.md
@@ -5,7 +5,9 @@ description: >
   Installing the CSI Driver for Dell PowerMax via Dell CSM Operator
 ---
 {{% pageinfo color="primary" %}}
-{{< message text="1" >}}
+1. <span></span>{{< message text="1" >}}
+
+2. <span></span>{{< message text="11" >}}
 {{% /pageinfo %}}
 The CSI Driver for Dell PowerMax can be installed via the Dell CSM Operator.
 To deploy the Operator, follow the instructions available [here](../../#installation).
@@ -367,73 +369,40 @@ Create a secret named powermax-certs in the namespace where the CSI PowerMax dri
 
 ### Install Driver
 
-1. Create namespace:
-   Run `kubectl create namespace <driver-namespace>` using the desired name to create the namespace.
-2. Create PowerMax credentials:
-   Create a file called powermax-creds.yaml with the following content:
-     ```yaml
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: powermax-creds
-            # Replace driver-namespace with the namespace where driver is being deployed
-          namespace: <driver-namespace>
-        type: Opaque
-        data:
-          # set username to the base64 encoded username
-          username: <base64 username>
-          # set password to the base64 encoded password
-          password: <base64 password>
-          # Uncomment the following key if you wish to use ISCSI CHAP authentication (v1.3.0 onwards)
-          # chapsecret: <base64 CHAP secret>
-     ```
-   Replace the values for the username and password parameters. These values can be obtained using base64 encoding as described in the following example:
+1. Create a namespace in which the driver will be installed.
    ```bash
-   echo -n "myusername" | base64
-   echo -n "mypassword" | base64
-   # If mychapsecret is the iSCSI CHAP secret
-   echo -n "mychapsecret" | base64
+   kubectl create namespace <driver-namespace>
    ```
-   Run the `kubectl create -f powermax-creds.yaml` command to create the secret.
-3. Create a configmap using sample [here](https://github.com/dell/csm-operator/tree/master/samples/csireverseproxy). Fill in the appropriate values for driver configuration.
-   Example: config.yaml
-   ```yaml
-   port: 2222 # Port on which reverseproxy will listen
-   logLevel: debug
-   logFormat: text
-   config:
-     storageArrays:
-        - storageArrayId: "000000000001" # arrayID
-          primaryURL: https://primary-1.unisphe.re:8443 # primary unisphere for arrayID
-          backupURL: https://backup-1.unisphe.re:8443   # backup unisphere for arrayID
-          proxyCredentialSecrets:
-            - primary-unisphere-secret-1 # credential secret for primary unisphere, e.g., powermax-creds
-            - backup-unisphere-secret-1 # credential secret for backup unisphere, e.g., powermax-creds
-        - storageArrayId: "000000000002"
-          primaryURL: https://primary-2.unisphe.re:8443
-          backupURL: https://backup-2.unisphe.re:8443
-          proxyCredentialSecrets:
-           - primary-unisphere-secret-2
-           - backup-unisphere-secret-2
-     managementServers:
-       - url: https://primary-1.unisphe.re:8443 # primary unisphere endpoint
-         arrayCredentialSecret: primary-unisphere-secret-1 # primary credential secret e.g., powermax-creds
-         skipCertificateValidation: true
-       - url: https://backup-1.unisphe.re:8443 # backup unisphere endpoint
-         arrayCredentialSecret: backup-unisphere-secret-1 # backup credential secret e.g., powermax-creds
-         skipCertificateValidation: false # value false, to verify unisphere certificate and provide certSecret
-         certSecret: primary-certs # unisphere verification certificate
-       - url: https://primary-2.unisphe.re:8443
-         arrayCredentialSecret: primary-unisphere-secret-2
-         skipCertificateValidation: true
-       - url: https://backup-2.unisphe.re:8443
-         arrayCredentialSecret: backup-unisphere-secret-2
-         skipCertificateValidation: false
-         certSecret: primary-certs
-   ```
-   After editing the file, run this command to create a secret called `powermax-reverseproxy-config`. If you are using a different namespace/secret name, just substitute those into the command.
+2. Create the `powermax-reverseproxy-secret` secret.
+
+    - *storageArrays*: A list of storage arrays and their associated details.
+      - *storageArrayId*: A unique PowerMax Symmetrix ID.
+      - *primaryEndpoint*: The URL of the Unisphere server managing this storage array.
+      - *backupEndpoint*: The URL of the backup Unisphere server managing this storage array; utilized if the primary server is unreachable.
+    - *managementServers*: A list of Unisphere management server endpoints and resources used to make connections with those servers.
+      - *endpoint*: The URL of the Unisphere server (primary or backup). This should match one of the URLs listed under `storageArrays`.
+      - *username*: The username to be used when connecting to the `endpoint`.
+      - *password*: The password to be used when connecting to the `endpoint`.
+      - *skipCertificateValidation*: Set to `false` to perform client-side TLS certificate verification for the Unisphere instance, `true` to skip verification.
+
+    ```yaml
+    storageArrays:
+      - storageArrayId: "000000000001"
+        primaryEndpoint: https://primary-1.unisphe.re:8443
+        backupEndpoint: https://backup-1.unisphe.re:8443
+    managementServers:
+      - endpoint: https://primary-1.unisphe.re:8443
+        username: admin
+        password: password
+        skipCertificateValidation: true
+      - endpoint: https://backup-1.unisphe.re:8443
+        username: admin2
+        password: password2
+        skipCertificateValidation: false
+    ```
+    After editing the file, run this command to create a secret called `powermax-reverseproxy-config`. If you are using a different namespace/secret name, just substitute those into the command.
     ```bash
-    kubectl create configmap powermax-reverseproxy-config --from-file config.yaml -n powermax
+    kubectl create secret generic powermax-reverseproxy-secret --namespace powermax --from-file=config=samples/secret/secret.yaml
     ```
 4. Create a configmap using the sample file [here](https://github.com/dell/csi-powermax/blob/main/samples/configmap/powermax-array-config.yaml). Fill in the appropriate values for driver configuration.
    ```yaml
@@ -510,6 +479,7 @@ Example:
    | X_CSI_VSPHERE_PORTGROUP                         | Existing portGroup that driver will use for vSphere                                                                                                                                                                                                                      | Yes      | ""                             |
    | X_CSI_VSPHERE_HOSTNAME                          | Existing host(initiator group)/host group(cascaded initiator group) that driver will use for vSphere                                                                                                                                                                     | Yes      | ""                             |
    | X_CSI_VCenter_HOST                              | URL/endpoint of the vCenter where all the ESX are present                                                                                                                                                                                                                | Yes      | ""                             |
+   | X_CSI_REVPROXY_USE_SECRET | Define whether or not to use the new secret format for the PowerMax and the Reverse Proxy. The secret used will be whatever secret is defined in the `authSecret`. **Note:** If this paramter remains `false`, PowerMax and the reverse proxy will use the configMap approach. | Yes      | "false" |
    | ***Node parameters***                           |                                                                                                                                                                                                                                                                          |          |                                |
    | X_CSI_POWERMAX_ISCSI_ENABLE_CHAP                | Enable ISCSI CHAP authentication. For more details on this feature see the related [documentation](../../../../csidriver/features/powermax/#iscsi-chap)                                                                                                                               | No       | false                          |
    | X_CSI_TOPOLOGY_CONTROL_ENABLED                  | Enable/Disabe topology control. It filters out arrays, associated transport protocol available to each node and creates topology keys based on any such user input.                                                                                                      | No       | false                          |

--- a/content/docs/deployment/helm/drivers/installation/powermax.md
+++ b/content/docs/deployment/helm/drivers/installation/powermax.md
@@ -5,7 +5,9 @@ description: >
   Installing the CSI Driver for Dell PowerMax via Helm
 ---
 {{% pageinfo color="primary" %}}
-{{< message text="1" >}}
+1. <span></span>{{< message text="11" >}}
+
+2. <span></span>{{< message text="1" >}}
 {{% /pageinfo %}}
 
 The CSI Driver for Dell PowerMax can be deployed by using the provided Helm v3 charts and installation scripts on both Kubernetes and OpenShift platforms. For more detailed information on the installation scripts, see the script [documentation](https://github.com/dell/csi-powermax/tree/master/dell-csi-helm-installer).

--- a/layouts/shortcodes/message.html
+++ b/layouts/shortcodes/message.html
@@ -19,7 +19,7 @@ We are thrilled to announce the launch of our brand-new <a href="https://dell.gi
 {{ else if eq (.Get "text") "10" }}
 Application Mobility will be part of the Container Storage Modules open-source suite in an upcoming release.
 {{ else if eq (.Get "text") "11" }}
-The CSI PowerMax Reverse Proxy Config Map will no longer be supported as of May 30, 2025 and completely deprecated by January 31, 2026. Please switch to using the CSI PowerMax Mount Credentials before these dates to prevent any potential disruptions. Migration steps are available for both <a href="/docs/deployment/helm/drivers/installation/powermax/#installation">Helm</a> and <a href="/docs/deployment/csmoperator/drivers/powermax/#install-driver">Operator</a>.
+The CSI PowerMax Reverse Proxy Config Map will no longer be supported as of May 30, 2025 and completely deprecated by January 31, 2026. Please switch to using the CSI PowerMax Mount Credentials before these dates to prevent any potential disruptions. Migration steps are available for both <a href="/docs/deployment/helm/drivers/upgrade/powermax/#update-driver-from-v2130-to-v2140-using-helm">Helm</a> and <a href="/docs/deployment/csmoperator/drivers/powermax/#install-driver">Operator</a>.
 {{else}}  
 <p>Default text if no valid parameter is passed.</p>
 {{ end }}

--- a/layouts/shortcodes/message.html
+++ b/layouts/shortcodes/message.html
@@ -18,6 +18,8 @@ Support for CSM via Slack will be deprecated on 5/31/2025, aligning with the CSM
 We are thrilled to announce the launch of our brand-new <a href="https://dell.github.io/beta-csm-docs/" target="_blank"> <b> Documentation Portal!</b></a>
 {{ else if eq (.Get "text") "10" }}
 Application Mobility will be part of the Container Storage Modules open-source suite in an upcoming release.
+{{ else if eq (.Get "text") "11" }}
+Starting with CSM 1.14, CSI PowerMax Reverse Proxy Config Map will be deprecated and will be officially discontinued by CSM 1.16. Please switch to using the CSI PowerMax Mount Credentials. Installation instrucation are stated for both Helm and Operator.
 {{else}}  
 <p>Default text if no valid parameter is passed.</p>
 {{ end }}

--- a/layouts/shortcodes/message.html
+++ b/layouts/shortcodes/message.html
@@ -19,7 +19,7 @@ We are thrilled to announce the launch of our brand-new <a href="https://dell.gi
 {{ else if eq (.Get "text") "10" }}
 Application Mobility will be part of the Container Storage Modules open-source suite in an upcoming release.
 {{ else if eq (.Get "text") "11" }}
-Starting with CSM 1.14, CSI PowerMax Reverse Proxy Config Map will be deprecated and will be officially discontinued by CSM 1.16. Please switch to using the CSI PowerMax Mount Credentials. Installation instrucation are stated for both Helm and Operator.
+The CSI PowerMax Reverse Proxy Config Map will no longer be supported as of May 30, 2025 and completely deprecated by January 31, 2026. Please switch to using the CSI PowerMax Mount Credentials before these dates to prevent any potential disruptions. Migration steps are available for both <a href="/docs/deployment/helm/drivers/installation/powermax/#installation">Helm</a> and <a href="/docs/deployment/csmoperator/drivers/powermax/#install-driver">Operator</a>.
 {{else}}  
 <p>Default text if no valid parameter is passed.</p>
 {{ end }}

--- a/layouts/shortcodes/message.html
+++ b/layouts/shortcodes/message.html
@@ -19,7 +19,7 @@ We are thrilled to announce the launch of our brand-new <a href="https://dell.gi
 {{ else if eq (.Get "text") "10" }}
 Application Mobility will be part of the Container Storage Modules open-source suite in an upcoming release.
 {{ else if eq (.Get "text") "11" }}
-The CSI PowerMax Reverse Proxy Config Map will no longer be supported as of May 30, 2025 and completely deprecated by January 31, 2026. Please switch to using the CSI PowerMax Mount Credentials before these dates to prevent any potential disruptions. Migration steps are available for both <a href="/docs/deployment/helm/drivers/upgrade/powermax/#update-driver-from-v2130-to-v2140-using-helm">Helm</a> and <a href="/docs/deployment/csmoperator/drivers/powermax/#install-driver">Operator</a>.
+The CSI PowerMax Reverse Proxy Config Map will no longer be supported as of May 30, 2025 and completely deprecated by January 31, 2026. Please switch to using the CSI PowerMax Mount Credentials before these dates to prevent any potential disruptions. Migration steps are available for both <a href="/csm-docs/docs/deployment/helm/drivers/upgrade/powermax/#update-driver-from-v2130-to-v2140-using-helm">Helm</a> and <a href="/csm-docs/docs/deployment/csmoperator/drivers/powermax/#install-driver">Operator</a>.
 {{else}}  
 <p>Default text if no valid parameter is passed.</p>
 {{ end }}


### PR DESCRIPTION
# Description
Updating install documentation to guide users through the process of installing csi-powermax using the reverse proxy secret with CSM Operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

