### PR TITLE
Fix the powermax-array-config not generated/configured correctly when using the Installation Wizard

### DIFF
--- a/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.12.0-values.template
+++ b/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.12.0-values.template
@@ -125,6 +125,10 @@ csi-powermax:
     managementServers:
       - endpoint: $POWERMAX_MANAGEMENT_SERVERS_ENDPOINT_URL
       - endpoint: $TARGET_UNISPHERE
+
+    portGroups: "$POWERMAX_PORT_GROUPS"
+    transportProtocol: "$NODE_TRANSPORT_PROTOCOL"
+    managedArrays: "$POWERMAX_STORAGE_ARRAY_ID"
   version: v2.12.0
   images:
     # "driver" defines the container image, used for the driver container.

--- a/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.12.0-values.template
+++ b/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.12.0-values.template
@@ -163,12 +163,10 @@ csi-powermax:
     noderescan:
       image: quay.io/dell/container-storage-modules/dell-csi-node-rescanner:v1.4.0
   clusterPrefix: $POWERMAX_CLUSTER_PREFIX
-  portGroups: "$POWERMAX_PORT_GROUPS"
   fsGroupPolicy: "$FSGROUP_POLICY"
   maxPowerMaxVolumesPerNode: $MAX_VOLUMES_PER_NODE
   podmonAPIPort: 8083
   enableCHAP: $ISCSI_CHAP_ENABLED
-  transportProtocol: "$NODE_TRANSPORT_PROTOCOL"
   storageCapacity:
     enabled: $STORAGE_CAPACITY_ENABLED
   controller:

--- a/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.13.0-values.template
+++ b/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.13.0-values.template
@@ -125,6 +125,10 @@ csi-powermax:
     managementServers:
       - endpoint: $POWERMAX_MANAGEMENT_SERVERS_ENDPOINT_URL
       - endpoint: $TARGET_UNISPHERE
+
+    portGroups: "$POWERMAX_PORT_GROUPS"
+    transportProtocol: "$NODE_TRANSPORT_PROTOCOL"
+    managedArrays: "$POWERMAX_STORAGE_ARRAY_ID"
   version: v2.13.0
   images:
     # "driver" defines the container image, used for the driver container.
@@ -159,12 +163,10 @@ csi-powermax:
     noderescan:
       image: quay.io/dell/container-storage-modules/dell-csi-node-rescanner:v1.4.0
   clusterPrefix: $POWERMAX_CLUSTER_PREFIX
-  portGroups: "$POWERMAX_PORT_GROUPS"
   fsGroupPolicy: "$FSGROUP_POLICY"
   maxPowerMaxVolumesPerNode: $MAX_VOLUMES_PER_NODE
   podmonAPIPort: 8083
   enableCHAP: $ISCSI_CHAP_ENABLED
-  transportProtocol: "$NODE_TRANSPORT_PROTOCOL"
   storageCapacity:
     enabled: $STORAGE_CAPACITY_ENABLED
   controller:


### PR DESCRIPTION
# Description
Fix the powermax-array-config not generated/configured correctly when using the Installation Wizard. Moving the 3 fields(transport protocol, managed arrays and port groups under global section

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| (https://github.com/dell/csm/issues/1786) |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [x] Have you added high-resolution images?
<img width="405" alt="new - Copy" src="https://github.com/user-attachments/assets/be0495cd-ce8d-43d7-b92f-168452f24ed9" />
