### PR TITLE
Add host based NFS capability

### DIFF
--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -770,7 +770,7 @@ The CSI PowerStore driver supports the provisioning of Metro volumes. The proces
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
 
 ## Shared NFS
-Shared NFS leverages native NFS capabilities to support large scale RWX volumes through AccessMode, allowing multiple consumers to share storage efficiently. It is based on a client-server model where a node acts as an NFS server (and maybe client too).
+Shared NFS utilizes native NFS features to support large-scale ReadWriteMany (RWX) volumes through the access mode, enabling efficient shared storage across multiple consumers. It follows a client-server model, with a node serving as an NFS server—and potentially a client as well.
 - **Scalability and Flexibility**: Offers enhanced scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
 - **Centralized File Management**: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
 - **NFSv4 Recommendation**: For optimal performance and compatibility, NFSv4 is recommended.

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -770,7 +770,7 @@ The CSI PowerStore driver supports the provisioning of Metro volumes. The proces
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
 
 ## Host Based NFS
-- Uses the NFS protocol to share files and directories over a network, operating on a client-server model where a host acts as an NFS server.
+Uses the NFS protocol to share files and directories over a network, operating on a client-server model where a host acts as an NFS server.
 - **Centralized File Management**: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
 - **Scalability and Flexibility**: Offers better scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
 - **NFSv4 Recommendation**: For optimal performance and compatibility, NFSv4 is recommended.

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -773,7 +773,7 @@ Please note that the Metro feature does not require the deployment of the replic
 Shared NFS utilizes native NFS features to support large-scale ReadWriteMany (RWX) volumes through the access mode, enabling efficient shared storage across multiple consumers. It follows a client-server model, with a node serving as an NFS server—and potentially a client as well.
 - **Scalability and Flexibility**: Offers enhanced scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
 - **Centralized File Management**: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
-- **NFSv4 Recommendation**: For optimal performance and compatibility, NFSv4 is recommended.
+- **NFSv4 Recommendation**: NFS versions v4,1, v4.2.
 - **Prerequisites**: NFS-related services (nfs-server and nfs-mountd on Linux) must be running on all participating worker nodes.
 - **CSI PowerStore Support**: Version 2.14 introduces support for Shared NFS via a new StorageClass.
 

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -770,18 +770,18 @@ The CSI PowerStore driver supports the provisioning of Metro volumes. The proces
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
 
 ## Shared NFS
-Uses the NFS protocol to share files and directories over a network, operating on a client-server model where a host acts as an NFS server.
+Shared NFS leverages native NFS capabilities to support large scale RWX volumes through AccessMode, allowing multiple consumers to share storage efficiently. It is based on a client-server model where a node acts as an NFS server (and maybe client too).
 - **Scalability and Flexibility**: Offers enhanced scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
 - **Centralized File Management**: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
 - **NFSv4 Recommendation**: For optimal performance and compatibility, NFSv4 is recommended.
 - **Prerequisites**: NFS-related services (nfs-server and nfs-mountd on Linux) must be running on all participating worker nodes.
-- **CSI PowerStore Support**: Version 2.14 introduces support for Host-Based NFS with a new StorageClass.
+- **CSI PowerStore Support**: Version 2.14 introduces support for Shared NFS via a new StorageClass.
 
 ```yaml
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: powerstore-hostbasednfs-sc
+    name: powerstore-sharednfs-sc
     annotations:
         storageclass.kubernetes.io/is-default-class: false
 provisioner: csi-powerstore.dellemc.com

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -770,7 +770,12 @@ The CSI PowerStore driver supports the provisioning of Metro volumes. The proces
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
 
 ## Host Based NFS
-Host-Based NFS leverages the Network File System (NFS) protocol to enable file and directory sharing over a network. It follows a client-server model in which a host functions as an NFS server—while optionally also acting as a client—sharing directories that can be mounted by other clients into their local file systems. This setup allows remote files to be accessed as if they were local. By centralizing files on a single host or a group of hosts, Host-Based NFS simplifies file management and reduces duplication, leading to more efficient storage use. Compared to traditional NFS, which relies on a single dedicated NFS server, Host-Based NFS offers improved scalability and flexibility. For optimal performance and compatibility, NFSv4 is recommended. A key prerequisite is that NFS-related services—specifically nfs-server and nfs-mountd on Linux—must be running on all participating worker nodes. CSI PowerStore version 2.14 introduces support for Host-Based NFS via a new StorageClass, defined as follows:
+- Uses the NFS protocol to share files and directories over a network, operating on a client-server model where a host acts as an NFS server.
+- Centralized File Management: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
+- Scalability and Flexibility: Offers better scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
+- NFSv4 Recommendation: For optimal performance and compatibility, NFSv4 is recommended.
+- Prerequisites: NFS-related services (nfs-server and nfs-mountd on Linux) must be running on all participating worker nodes.
+- CSI PowerStore Support: Version 2.14 introduces support for Host-Based NFS with a new StorageClass.
 
 ```yaml
 apiVersion: storage.k8s.io/v1

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -771,11 +771,11 @@ Please note that the Metro feature does not require the deployment of the replic
 
 ## Host Based NFS
 - Uses the NFS protocol to share files and directories over a network, operating on a client-server model where a host acts as an NFS server.
-- Centralized File Management: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
-- Scalability and Flexibility: Offers better scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
-- NFSv4 Recommendation: For optimal performance and compatibility, NFSv4 is recommended.
-- Prerequisites: NFS-related services (nfs-server and nfs-mountd on Linux) must be running on all participating worker nodes.
-- CSI PowerStore Support: Version 2.14 introduces support for Host-Based NFS with a new StorageClass.
+- **Centralized File Management**: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
+- **Scalability and Flexibility**: Offers better scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
+- **NFSv4 Recommendation**: For optimal performance and compatibility, NFSv4 is recommended.
+- **Prerequisites**: NFS-related services (nfs-server and nfs-mountd on Linux) must be running on all participating worker nodes.
+- **CSI PowerStore Support**: Version 2.14 introduces support for Host-Based NFS with a new StorageClass.
 
 ```yaml
 apiVersion: storage.k8s.io/v1

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -769,10 +769,10 @@ The CSI PowerStore driver supports the provisioning of Metro volumes. The proces
 
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
 
-## Host Based NFS
+## Shared NFS
 Uses the NFS protocol to share files and directories over a network, operating on a client-server model where a host acts as an NFS server.
+- **Scalability and Flexibility**: Offers enhanced scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
 - **Centralized File Management**: Allows remote files to be accessed as if they were local, simplifying file management and reducing duplication for more efficient storage use.
-- **Scalability and Flexibility**: Offers better scalability and flexibility compared to traditional NFS, which relies on a single dedicated server.
 - **NFSv4 Recommendation**: For optimal performance and compatibility, NFSv4 is recommended.
 - **Prerequisites**: NFS-related services (nfs-server and nfs-mountd on Linux) must be running on all participating worker nodes.
 - **CSI PowerStore Support**: Version 2.14 introduces support for Host-Based NFS with a new StorageClass.

--- a/content/docs/concepts/csidriver/features/powerstore.md
+++ b/content/docs/concepts/csidriver/features/powerstore.md
@@ -768,3 +768,25 @@ To configure how often driver checks for changed capacity set `storageCapacity.p
 The CSI PowerStore driver supports the provisioning of Metro volumes. The process and details of how to provision and use Metro volumes can be found [here](../../../replication/high-availability).
 
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
+
+## Host Based NFS
+Host-Based NFS leverages the Network File System (NFS) protocol to enable file and directory sharing over a network. It follows a client-server model in which a host functions as an NFS server—while optionally also acting as a client—sharing directories that can be mounted by other clients into their local file systems. This setup allows remote files to be accessed as if they were local. By centralizing files on a single host or a group of hosts, Host-Based NFS simplifies file management and reduces duplication, leading to more efficient storage use. Compared to traditional NFS, which relies on a single dedicated NFS server, Host-Based NFS offers improved scalability and flexibility. For optimal performance and compatibility, NFSv4 is recommended. A key prerequisite is that NFS-related services—specifically nfs-server and nfs-mountd on Linux—must be running on all participating worker nodes. CSI PowerStore version 2.14 introduces support for Host-Based NFS via a new StorageClass, defined as follows:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: powerstore-hostbasednfs-sc
+    annotations:
+        storageclass.kubernetes.io/is-default-class: false
+provisioner: csi-powerstore.dellemc.com
+reclaimPolicy: Delete
+parameters:
+  arrayID: <array-id>
+  csi-nfs: RWX
+  csi.storage.k8s.io/fstype: ext4
+provisioner: csi-powerstore.dellemc.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+```

--- a/content/docs/getting-started/installation/kubernetes/powerstore/prerequisite/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powerstore/prerequisite/_index.md
@@ -16,7 +16,7 @@ The following requirements must be met before installing the CSI Driver for Powe
 - Insecure registries are defined in Docker or other container runtime for CSI drivers that are hosted in a non-secure location.
 - Ensure that your nodes support mounting NFS volumes if using NFS.
 - For NVMe support the preferred multipath solution is NVMe native multipathing. The [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault/pdf/Linux.pdf) describes the details of each configuration option.
-- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes.
+- For "Shared NFS" - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes.
 
 {{< tabpane text=true lang="en" >}}
 {{% tab header="Fibre Channel" lang="en" %}}

--- a/content/docs/getting-started/installation/kubernetes/powerstore/prerequisite/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powerstore/prerequisite/_index.md
@@ -16,6 +16,7 @@ The following requirements must be met before installing the CSI Driver for Powe
 - Insecure registries are defined in Docker or other container runtime for CSI drivers that are hosted in a non-secure location.
 - Ensure that your nodes support mounting NFS volumes if using NFS.
 - For NVMe support the preferred multipath solution is NVMe native multipathing. The [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault/pdf/Linux.pdf) describes the details of each configuration option.
+- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes.
 
 {{< tabpane text=true lang="en" >}}
 {{% tab header="Fibre Channel" lang="en" %}}

--- a/content/docs/getting-started/installation/openshift/powerstore/prerequisite/_index.md
+++ b/content/docs/getting-started/installation/openshift/powerstore/prerequisite/_index.md
@@ -17,6 +17,7 @@ The following requirements must be met before installing the CSI Driver for Powe
 - Insecure registries are defined in Docker or other container runtime for CSI drivers that are hosted in a non-secure location.
 - Ensure that your nodes support mounting NFS volumes if using NFS.
 - For NVMe support the preferred multipath solution is NVMe native multipathing. The [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault/pdf/Linux.pdf) describes the details of each configuration option.
+- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes.
 
 {{< tabpane text=true lang="en" >}}
 {{% tab header="Fibre Channel" lang="en" %}}

--- a/content/docs/getting-started/installation/openshift/powerstore/prerequisite/_index.md
+++ b/content/docs/getting-started/installation/openshift/powerstore/prerequisite/_index.md
@@ -17,7 +17,7 @@ The following requirements must be met before installing the CSI Driver for Powe
 - Insecure registries are defined in Docker or other container runtime for CSI drivers that are hosted in a non-secure location.
 - Ensure that your nodes support mounting NFS volumes if using NFS.
 - For NVMe support the preferred multipath solution is NVMe native multipathing. The [Dell Host Connectivity Guide](https://elabnavigator.dell.com/vault/pdf/Linux.pdf) describes the details of each configuration option.
-- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes.
+- For "Shared NFS" - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes.
 
 {{< tabpane text=true lang="en" >}}
 {{% tab header="Fibre Channel" lang="en" %}}

--- a/content/v1/csidriver/features/powerstore.md
+++ b/content/v1/csidriver/features/powerstore.md
@@ -769,3 +769,24 @@ To configure how often driver checks for changed capacity set `storageCapacity.p
 The CSI PowerStore driver supports the provisioning of Metro volumes. The process and details of how to provision and use Metro volumes can be found [here](../../../replication/high-availability).
 
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
+
+## Host Based NFS
+Host-Based NFS leverages the Network File System (NFS) protocol to enable file and directory sharing over a network. It follows a client-server model in which a host functions as an NFS server—while optionally also acting as a client—sharing directories that can be mounted by other clients into their local file systems. This setup allows remote files to be accessed as if they were local. By centralizing files on a single host or a group of hosts, Host-Based NFS simplifies file management and reduces duplication, leading to more efficient storage use. Compared to traditional NFS, which relies on a single dedicated NFS server, Host-Based NFS offers improved scalability and flexibility. For optimal performance and compatibility, NFSv4 is recommended. A key prerequisite is that NFS-related services—specifically nfs-server and nfs-mountd on Linux—must be running on all participating worker nodes. CSI PowerStore version 2.14 introduces support for Host-Based NFS via a new StorageClass, defined as follows:
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: powerstore-hostbasednfs-sc
+    annotations:
+        storageclass.kubernetes.io/is-default-class: false
+provisioner: csi-powerstore.dellemc.com
+reclaimPolicy: Delete
+parameters:
+  arrayID: <array-id>
+  csi-nfs: RWX
+  csi.storage.k8s.io/fstype: ext4
+provisioner: csi-powerstore.dellemc.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+
+```

--- a/content/v1/csidriver/features/powerstore.md
+++ b/content/v1/csidriver/features/powerstore.md
@@ -769,24 +769,3 @@ To configure how often driver checks for changed capacity set `storageCapacity.p
 The CSI PowerStore driver supports the provisioning of Metro volumes. The process and details of how to provision and use Metro volumes can be found [here](../../../replication/high-availability).
 
 Please note that the Metro feature does not require the deployment of the replicator sidecar or the replication controller.
-
-## Host Based NFS
-Host-Based NFS leverages the Network File System (NFS) protocol to enable file and directory sharing over a network. It follows a client-server model in which a host functions as an NFS server—while optionally also acting as a client—sharing directories that can be mounted by other clients into their local file systems. This setup allows remote files to be accessed as if they were local. By centralizing files on a single host or a group of hosts, Host-Based NFS simplifies file management and reduces duplication, leading to more efficient storage use. Compared to traditional NFS, which relies on a single dedicated NFS server, Host-Based NFS offers improved scalability and flexibility. For optimal performance and compatibility, NFSv4 is recommended. A key prerequisite is that NFS-related services—specifically nfs-server and nfs-mountd on Linux—must be running on all participating worker nodes. CSI PowerStore version 2.14 introduces support for Host-Based NFS via a new StorageClass, defined as follows:
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-    name: powerstore-hostbasednfs-sc
-    annotations:
-        storageclass.kubernetes.io/is-default-class: false
-provisioner: csi-powerstore.dellemc.com
-reclaimPolicy: Delete
-parameters:
-  arrayID: <array-id>
-  csi-nfs: RWX
-  csi.storage.k8s.io/fstype: ext4
-provisioner: csi-powerstore.dellemc.com
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
-
-```

--- a/content/v1/deployment/csmoperator/drivers/powerflex.md
+++ b/content/v1/deployment/csmoperator/drivers/powerflex.md
@@ -26,6 +26,8 @@ kubectl get csm --all-namespaces
 
 >NOTE: This step can be skipped with OpenShift.
 
+- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes. 
+
 #### SDC Deployment for Operator
 
 - This feature deploys the sdc kernel modules on all nodes with the help of an init container.

--- a/content/v1/deployment/csmoperator/drivers/powerflex.md
+++ b/content/v1/deployment/csmoperator/drivers/powerflex.md
@@ -26,8 +26,6 @@ kubectl get csm --all-namespaces
 
 >NOTE: This step can be skipped with OpenShift.
 
-- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes. 
-
 #### SDC Deployment for Operator
 
 - This feature deploys the sdc kernel modules on all nodes with the help of an init container.

--- a/content/v1/deployment/helm/drivers/installation/powerflex.md
+++ b/content/v1/deployment/helm/drivers/installation/powerflex.md
@@ -23,8 +23,7 @@ The following are requirements that must be met before installing the CSI Driver
 - A user must exist on the array with a role _>= FrontEndConfigure_
 - If enabling CSM for Authorization, please refer to the [Authorization deployment steps](../../../../../deployment/helm/modules/installation/authorization-v2.0/) first
 - If multipath is configured, ensure CSI-PowerFlex volumes are blacklisted by multipathd. See [troubleshooting section](../../../../../csidriver/troubleshooting/powerflex) for details
-- Secure boot is not supported; ensure that secure boot is disabled in the BIOS.
-- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes. 
+- Secure boot is not supported; ensure that secure boot is disabled in the BIOS. 
 
 ### Install Helm 3.x
 

--- a/content/v1/deployment/helm/drivers/installation/powerflex.md
+++ b/content/v1/deployment/helm/drivers/installation/powerflex.md
@@ -24,6 +24,7 @@ The following are requirements that must be met before installing the CSI Driver
 - If enabling CSM for Authorization, please refer to the [Authorization deployment steps](../../../../../deployment/helm/modules/installation/authorization-v2.0/) first
 - If multipath is configured, ensure CSI-PowerFlex volumes are blacklisted by multipathd. See [troubleshooting section](../../../../../csidriver/troubleshooting/powerflex) for details
 - Secure boot is not supported; ensure that secure boot is disabled in the BIOS.
+- If using Host Based NFS - Install necessary nfs packages and ensure nfs-server and nfs-mountd services are active and running on all nodes. 
 
 ### Install Helm 3.x
 


### PR DESCRIPTION
# Description
Add shared NFS (host based NFS) capability. It provides an outline of the feature with a sample storage class. Also added a line in prerequisites for helm and operator installation of CSI powerstore driver. 


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1742 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [x] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

