### PR TITLE
Update hugo Deployment Steps

### DIFF
--- a/content/docs/support/contributionguidelines/_index.md
+++ b/content/docs/support/contributionguidelines/_index.md
@@ -82,7 +82,6 @@ The Container Storage Modules documentation portal follows a release branch stra
 - Install [latest Hugo version extended version](https://github.com/gohugoio/hugo/releases). 
     > Note: Please note we have to install an extended version.
 - Create a local copy of the csm-docs repository using `git clone`. 
-- Update docsy submodules inside themes folder using `git submodule update --recursive --init`
 - Change to the csm-docs folder and run 
     ```
     hugo server 


### PR DESCRIPTION
# Description
Removed the git submodule update --recursive --init step from the "Previewing your changes" subsection under the Contributing Guidelines, as it is no longer required. Verified that the site builds and runs correctly without it.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1707|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

