### PR TITLE
Fix: Use Proper PAT for Release Notes Generation

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -87,11 +87,11 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          branch: "release-notes-update"
+          branch: "docs/relnotes-update"
           commit-message: "Update Release Notes"
           title: "Update Release Notes"
           body: |
-            Update release-notes to include features and bug fixes.
+            Update the Release Notes to include features and bug fixes.
           sign-commits: true
           delete-branch: true
           draft: true

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -46,7 +46,7 @@ jobs:
             MILESTONE=${{ inputs.version }}
           fi
 
-          git clone https://${GITHUB_TOKEN}@github.com/dell/csm-change-log.git
+          git clone https://github.com/dell/csm-change-log.git
           cd csm-change-log
 
           # Update labels for release Notes

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Generate Release Notes
         env:
-          GITHUB_TOKEN: ${{ secrets.CSM_RELEASE_APP_PRIVATE_KEY }}
+          GITHUB_TOKEN: ${{ secrets.CSMBOT_PAT }}
         run: |
           # Go back to not clone within the repo.
           cd ..
@@ -46,7 +46,7 @@ jobs:
             MILESTONE=${{ inputs.version }}
           fi
 
-          git clone https://github.com/dell/csm-change-log.git
+          git clone https://${GITHUB_TOKEN}@github.com/dell/csm-change-log.git
           cd csm-change-log
 
           # Update labels for release Notes

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -46,7 +46,7 @@ jobs:
             MILESTONE=${{ inputs.version }}
           fi
 
-          git clone https://github.com/dell/csm-change-log.git
+          git clone https://${GITHUB_TOKEN}@github.com/dell/csm-change-log.git
           cd csm-change-log
 
           # Update labels for release Notes

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -75,22 +75,22 @@ jobs:
           cd ../
           rm -rf change-log
 
-      - uses: actions/create-github-app-token@v2.0.5
-        id: generate-token
-        with:
-          app-id: ${{ vars.CSM_RELEASE_APP_ID }}
-          private-key: ${{ secrets.CSM_RELEASE_APP_PRIVATE_KEY }}
+      # - uses: actions/create-github-app-token@v2.0.5
+      #   id: generate-token
+      #   with:
+      #     app-id: ${{ vars.CSM_RELEASE_APP_ID }}
+      #     private-key: ${{ secrets.CSM_RELEASE_APP_PRIVATE_KEY }}
 
-      # Must enable "allow GitHub Actions to create pull requests" setting
-      # Author defaults to the user who triggered the workflow run
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          branch: "release-notes-update"
-          commit-message: "Update Release Notes"
-          title: "Update Release Notes"
-          body: |
-            Update release-notes to include features and bug fixes.
-          sign-commits: true
-          delete-branch: true
+      # # Must enable "allow GitHub Actions to create pull requests" setting
+      # # Author defaults to the user who triggered the workflow run
+      # - name: Create pull request
+      #   uses: peter-evans/create-pull-request@v7
+      #   with:
+      #     token: ${{ steps.generate-token.outputs.token }}
+      #     branch: "release-notes-update"
+      #     commit-message: "Update Release Notes"
+      #     title: "Update Release Notes"
+      #     body: |
+      #       Update release-notes to include features and bug fixes.
+      #     sign-commits: true
+      #     delete-branch: true

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -75,22 +75,23 @@ jobs:
           cd ../
           rm -rf change-log
 
-      # - uses: actions/create-github-app-token@v2.0.5
-      #   id: generate-token
-      #   with:
-      #     app-id: ${{ vars.CSM_RELEASE_APP_ID }}
-      #     private-key: ${{ secrets.CSM_RELEASE_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v2.0.5
+        id: generate-token
+        with:
+          app-id: ${{ vars.CSM_RELEASE_APP_ID }}
+          private-key: ${{ secrets.CSM_RELEASE_APP_PRIVATE_KEY }}
 
-      # # Must enable "allow GitHub Actions to create pull requests" setting
-      # # Author defaults to the user who triggered the workflow run
-      # - name: Create pull request
-      #   uses: peter-evans/create-pull-request@v7
-      #   with:
-      #     token: ${{ steps.generate-token.outputs.token }}
-      #     branch: "release-notes-update"
-      #     commit-message: "Update Release Notes"
-      #     title: "Update Release Notes"
-      #     body: |
-      #       Update release-notes to include features and bug fixes.
-      #     sign-commits: true
-      #     delete-branch: true
+      # Must enable "allow GitHub Actions to create pull requests" setting
+      # Author defaults to the user who triggered the workflow run
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          branch: "release-notes-update"
+          commit-message: "Update Release Notes"
+          title: "Update Release Notes"
+          body: |
+            Update release-notes to include features and bug fixes.
+          sign-commits: true
+          delete-branch: true
+          draft: true


### PR DESCRIPTION
# Description
Update the `GITHUB_TOKEN` to correct PAT.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1707 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

# Results:
- [x] Run generation of release notes through GitHub Action (https://github.com/dell/csm-docs/pull/1528)
