### PR TITLE
Revert the Powermax Metro note

### DIFF
--- a/content/docs/getting-started/installation/kubernetes/powermax/csmoperator/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powermax/csmoperator/_index.md
@@ -86,8 +86,6 @@ To deploy the Operator, follow the instructions available [here](../../../operat
 
     b. **Detailed Configuration:** Use the [sample file](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="Det_sample_operator_pmax" >}}.yaml) for detailed settings or use [Wizard](./installationwizard#generate-manifest-file) to generate the sample file. 
 
-> NOTE:
-> [Replication module](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="sample_sc_pmax" >}}.yaml#L283) must be enabled to use the Metro volume
 
 
   - Users should configure the parameters in CR. The following table lists the primary configurable parameters of the PowerMax driver and their default values:

--- a/content/docs/getting-started/installation/kubernetes/powermax/csmoperator/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powermax/csmoperator/_index.md
@@ -89,18 +89,6 @@ To deploy the Operator, follow the instructions available [here](../../../operat
 > NOTE:
 > [Replication module](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="sample_sc_pmax" >}}.yaml#L283) must be enabled to use the Metro volume
 
-Example:
-```yaml
-    - name: replication
-      enabled: true
-```
->  [Target clusterID](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="sample_sc_pflex" >}}.yaml#L316) should be set as self
-
-Example:
-```yaml
-    - name: "TARGET_CLUSTERS_IDS"
-      value: "self"
-```
 
   - Users should configure the parameters in CR. The following table lists the primary configurable parameters of the PowerMax driver and their default values:
 

--- a/content/docs/getting-started/installation/openshift/powermax/csmoperator/_index.md
+++ b/content/docs/getting-started/installation/openshift/powermax/csmoperator/_index.md
@@ -145,21 +145,6 @@ dell-csm-operator-controller-manager-86dcdc8c48-6dkxm      2/2     Running      
 
     b. **Detailed Configuration:** Use the [sample file](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="Det_sample_operator_pmax" >}}.yaml) for detailed settings.
 
-> NOTE:
-> [Replication module](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="sample_sc_pmax" >}}.yaml#L283) must be enabled to use the Metro volume
-
-Example:
-```yaml
-    - name: replication
-      enabled: true
-```
->  [Target clusterID](https://github.com/dell/csm-operator/blob/main/samples/storage_csm_powermax_{{< version-docs key="sample_sc_pmax" >}}.yaml#L316) should be set as self
-
-Example:
-```yaml
-    - name: "TARGET_CLUSTERS_IDS"
-      value: "self"
-```
 
   - Users should configure the parameters in CR. The following table lists the primary configurable parameters of the PowerMax driver and their default values:
 


### PR DESCRIPTION
# Description
Revert the Powermax Metro note from v1.14 doc
Issue is addressed in https://github.com/dell/csi-powermax/pull/417 and https://github.com/dell/csm-docs/pull/1429

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1711|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

![image](https://github.com/user-attachments/assets/e28bf51e-2cfb-4bbf-a462-633dc8665b58)

![image](https://github.com/user-attachments/assets/7ca3e293-296b-4410-a59c-9b9d5ee94aea)

