### PR TITLE
Update image of PowerStore Metro Architecture

### DIFF
--- a/content/docs/concepts/replication/high-availability/powerstore-metro.md
+++ b/content/docs/concepts/replication/high-availability/powerstore-metro.md
@@ -8,7 +8,7 @@ description: >
 
 ## PowerStore Metro Architecture
 
-![metro architecture diagram](../../../../../images/replication/metro.png)
+![metro architecture diagram](../../../../../images/replication/powerstore-metro.png)
 
 In PowerStore Metro configurations:
 * The application host can write data to both sides of the Metro volume.


### PR DESCRIPTION
# Description
This PR replaces the incorrect metro architecture diagram that was previously showing PowerMax with the correct diagram for PowerStore. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| dell/csm#1898|

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [x] Have you added high-resolution images?

Screenshot:
![image](https://github.com/user-attachments/assets/4adacabb-1394-4e27-b169-1e173ccbf418)
