### PR TITLE
Add CSI Sidecars Update Action

### DIFF
--- a/.github/workflows/csi-sidecars-update.yaml
+++ b/.github/workflows/csi-sidecars-update.yaml
@@ -15,6 +15,6 @@ on:
 
 jobs:
   csi-sidecars-update:
-    uses: dellc/common-github-actions/.github/workflows/csi-sidecars-update.yaml@main
+    uses: dell/common-github-actions/.github/workflows/csi-sidecars-update.yaml@main
     name: CSI Sidecars Update
     secrets: inherit

--- a/.github/workflows/csi-sidecars-update.yaml
+++ b/.github/workflows/csi-sidecars-update.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+name: Update CSI Sidecars
+
+on:
+  workflow_dispatch:  # Allows manual trigger
+    schedule:
+    - cron: '0 1 * * 1'  # Runs every Monday at 01:00
+
+jobs:
+  csi-sidecars-update:
+    uses: dellc/common-github-actions/.github/workflows/csi-sidecars-update.yaml@main
+    name: CSI Sidecars Update
+    secrets: inherit

--- a/.github/workflows/csi-sidecars-update.yaml
+++ b/.github/workflows/csi-sidecars-update.yaml
@@ -11,7 +11,7 @@ name: Update CSI Sidecars
 on:
   workflow_dispatch:  # Allows manual trigger
     schedule:
-    - cron: '0 1 * * 1'  # Runs every Monday at 01:00
+    - cron: '0 0 * * 3'  # Runs every Wednesday at Midnight
 
 jobs:
   csi-sidecars-update:

--- a/content/docs/getting-started/installation/offline/helm.md
+++ b/content/docs/getting-started/installation/offline/helm.md
@@ -41,11 +41,11 @@ quay.io/dell/container-storage-modules/csi-metadata-retriever:{{< version-docs k
 quay.io/dell/container-storage-modules/csi-powerstore:{{< version-docs key="PStore_latestVersion" >}}
 quay.io/dell/container-storage-modules/dell-csi-replicator:{{< version-docs key="replicator_latest_version" >}}
 quay.io/dell/container-storage-modules/podmon:{{< version-docs key="podmon_latest_version" >}}
-registry.k8s.io/sig-storage/csi-attacher:{{< version-docs key="attacher_latest_version" >}}
-registry.k8s.io/sig-storage/csi-external-health-monitor-controller:{{< version-docs key="health_monitor_controller_latest_version" >}}
-registry.k8s.io/sig-storage/csi-node-driver-registrar:{{< version-docs key="node_driver_registrar_latest_version" >}}
-registry.k8s.io/sig-storage/csi-provisioner:{{< version-docs key="provisioner_latest_version" >}}
-registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="resizer_latest_version" >}}
+registry.k8s.io/sig-storage/csi-attacher:{{< version-docs key="csi_attacher_latest_version" >}}
+registry.k8s.io/sig-storage/csi-external-health-monitor-controller:{{< version-docs key="csi_external_health_monitor_controller_latest_version" >}}
+registry.k8s.io/sig-storage/csi-node-driver-registrar:{{< version-docs key="csi_node_driver_registrar_latest_version" >}}
+registry.k8s.io/sig-storage/csi-provisioner:{{< version-docs key="csi_provisioner_latest_version" >}}
+registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}}
 registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}}
 
 *
@@ -77,16 +77,16 @@ csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/common.sh
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/verify-csi-powerstore.sh
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/
-csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-resizer-{{< version-docs key="resizer_latest_version" >}}.tar
+csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-resizer-{{< version-docs key="csi_resizer_latest_version" >}}.tar
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-csi-metadata-retriever-{{< version-docs key="metadata_retriever_latest_version" >}}.tar
-csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-attacher-{{< version-docs key="attacher_latest_version" >}}.tar
+csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-attacher-{{< version-docs key="csi_attacher_latest_version" >}}.tar
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-csi-powerstore-{{< version-docs key="PStore_latestVersion" >}}.tar
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-snapshotter-{{< version-docs key="csi_snapshotter_latest_version" >}}.tar
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-dell-csi-replicator-{{< version-docs key="replicator_latest_version" >}}.tar
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-podmon-{{< version-docs key="podmon_latest_version" >}}.tar
-csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-external-health-monitor-controller-{{< version-docs key="health_monitor_controller_latest_version" >}}.tar
-csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-node-driver-registrar-{{< version-docs key="node_driver_registrar_latest_version" >}}.tar
-csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-provisioner-{{< version-docs key="provisioner_latest_version" >}}.tar
+csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-external-health-monitor-controller-{{< version-docs key="csi_external_health_monitor_controller_latest_version" >}}.tar
+csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-node-driver-registrar-{{< version-docs key="csi_node_driver_registrar_latest_version" >}}.tar
+csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-provisioner-{{< version-docs key="csi_provisioner_latest_version" >}}.tar
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/csi-offline-bundle.md
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/.gitignore
 csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/README.md
@@ -128,16 +128,16 @@ Offline bundle file is: ~/csi-<driver>/csi-<driver>-bundle-2.14.0.tar.gz
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/common.sh
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/verify-csi-<driver>.sh
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/
-  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-resizer-{{< version-docs key="resizer_latest_version" >}}.tar
+  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-resizer-{{< version-docs key="csi_resizer_latest_version" >}}.tar
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-csi-metadata-retriever-{{< version-docs key="metadata_retriever_latest_version" >}}.tar
-  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-attacher-{{< version-docs key="attacher_latest_version" >}}.tar
+  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-attacher-{{< version-docs key="csi_attacher_latest_version" >}}.tar
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-csi-<driver>-{{< version-docs key="PStore_latestVersion" >}}.tar
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-snapshotter-{{< version-docs key="csi_snapshotter_latest_version" >}}.tar
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-dell-csi-replicator-{{< version-docs key="replicator_latest_version" >}}.tar
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/quay.io-dell-container-storage-modules-podmon-{{< version-docs key="podmon_latest_version" >}}.tar
-  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-external-health-monitor-controller-{{< version-docs key="health_monitor_controller_latest_version" >}}.tar
-  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-node-driver-registrar-{{< version-docs key="node_driver_registrar_latest_version" >}}.tar
-  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-provisioner-{{< version-docs key="provisioner_latest_version" >}}.tar
+  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-external-health-monitor-controller-{{< version-docs key="csi_external_health_monitor_controller_latest_version" >}}.tar
+  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-node-driver-registrar-{{< version-docs key="csi_node_driver_registrar_latest_version" >}}.tar
+  csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-provisioner-{{< version-docs key="csi_provisioner_latest_version" >}}.tar
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/csi-offline-bundle.md
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/.gitignore
   csi-<driver>-bundle-2.14.0/dell-csi-helm-installer/README.md

--- a/content/docs/getting-started/installation/offline/operator.md
+++ b/content/docs/getting-started/installation/offline/operator.md
@@ -72,11 +72,11 @@ Here is the output of a request to build an offline bundle for the Dell CSM Oper
    registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16.0-202409051837.p0.g8ea2c99.assembly.stream.el9
    nginxinc/nginx-unprivileged:1.27
    otel/opentelemetry-collector:0.42.0
-   registry.k8s.io/sig-storage/csi-attacher:{{< version-docs key="attacher_latest_version" >}}
-   registry.k8s.io/sig-storage/csi-external-health-monitor-controller:{{< version-docs key="health_monitor_controller_latest_version" >}}
-   registry.k8s.io/sig-storage/csi-node-driver-registrar:{{< version-docs key="node_driver_registrar_latest_version" >}}
-   registry.k8s.io/sig-storage/csi-provisioner:{{< version-docs key="provisioner_latest_version" >}}
-   registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="resizer_latest_version" >}}
+   registry.k8s.io/sig-storage/csi-attacher:{{< version-docs key="csi_attacher_latest_version" >}}
+   registry.k8s.io/sig-storage/csi-external-health-monitor-controller:{{< version-docs key="csi_external_health_monitor_controller_latest_version" >}}
+   registry.k8s.io/sig-storage/csi-node-driver-registrar:{{< version-docs key="csi_node_driver_registrar_latest_version" >}}
+   registry.k8s.io/sig-storage/csi-provisioner:{{< version-docs key="csi_provisioner_latest_version" >}}
+   registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}}
    registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}}
 
 * Copying necessary files
@@ -167,7 +167,7 @@ Loaded image: quay.io/dell/container-storage-modules/csi-powerstore:{{< version-
 Loaded image: quay.io/dell/container-storage-modules/csi-isilon:{{< version-docs key="PScale_latestVersion" >}}
 ...
 ...
-Loaded image: registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="resizer_latest_version" >}}
+Loaded image: registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}}
 Loaded image: registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}}
 
 * Tagging and pushing images
@@ -176,7 +176,7 @@ Loaded image: registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="
    quay.io/dell/container-storage-modules/csi-metadata-retriever:{{< version-docs key="metadata_retriever_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-metadata-retriever:{{< version-docs key="metadata_retriever_latest_version" >}}
    ...
    ...
-   registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="resizer_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-resizer:{{< version-docs key="resizer_latest_version" >}}
+   registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}}
    registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}}
 
 * Preparing files within /root/dell-csm-operator-bundle
@@ -185,7 +185,7 @@ Loaded image: registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="
    changing: quay.io/dell/container-storage-modules/csi-metadata-retriever:{{< version-docs key="metadata_retriever_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-metadata-retriever:{{< version-docs key="metadata_retriever_latest_version" >}}
    ...
    ...
-   changing: registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="resizer_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-resizer:{{< version-docs key="resizer_latest_version" >}}
+   changing: registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}}
    changing: registry.k8s.io/sig-storage/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}} -> localregistry:5000/dell-csm-operator/csi-snapshotter:{{< version-docs key="csi_snapshotter_latest_version" >}}
 
 * Complete

--- a/content/docs/tooling/cli/_index.md
+++ b/content/docs/tooling/cli/_index.md
@@ -799,12 +799,12 @@ dellctl images --component csi-vxflexos
 
 ```bash
 Driver/Module Image             Supported Orchestrator Versions         Sidecar Images
-quay.io/dell/container-storage-modules/csi-vxflexos:v2.13.0     k8s1.32,k8s1.31,k8s1.30,ocp4.18,ocp4.17 registry.k8s.io/sig-storage/csi-attacher:v4.7.0
-                                                                        registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
-                                                                        registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.13.0
-                                                                        registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
-                                                                        registry.k8s.io/sig-storage/csi-resizer:v1.12.0
-                                                                        registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
+quay.io/dell/container-storage-modules/csi-vxflexos:v2.13.0     k8s1.32,k8s1.31,k8s1.30,ocp4.18,ocp4.17 registry.k8s.io/sig-storage/csi-attacher:{{< version-docs key="csi_attacher_latest_version" >}}
+                                                                        registry.k8s.io/sig-storage/csi-provisioner:{{< version-docs key="csi_provisioner_latest_version" >}}
+                                                                        registry.k8s.io/sig-storage/csi-external-health-monitor-controller:{{< version-docs key="csi_health_monitor_controller_latest_version" >}}
+                                                                        registry.k8s.io/sig-storage/csi-snapshotter:{{< version-v1 key="csi_snapshotter_latest_version" >}}
+                                                                        registry.k8s.io/sig-storage/csi-resizer:{{< version-docs key="csi_resizer_latest_version" >}}
+                                                                        registry.k8s.io/sig-storage/csi-node-driver-registrar:{{< version-docs key="csi_node_driver_registrar_latest_version" >}}
                                                                         quay.io/dell/storage/powerflex/sdc:4.5.2.1
 
 ```

--- a/layouts/shortcodes/version-docs.html
+++ b/layouts/shortcodes/version-docs.html
@@ -50,11 +50,11 @@
 {{- else if eq $key "sample_sc_pscale" -}}v2140
 {{- else if eq $key "sample_sc_unity" -}}v2140
 {{- else if eq $key "csm-operator_latest_version" -}}v1.9.0
-{{- else if eq $key "attacher_latest_version" -}}v4.8.1
-{{- else if eq $key "health_monitor_controller_latest_version" -}}v0.14.0
-{{- else if eq $key "node_driver_registrar_latest_version" -}}v2.13.0
-{{- else if eq $key "provisioner_latest_version" -}}v5.2.0
-{{- else if eq $key "resizer_latest_version" -}}v1.13.2
+{{- else if eq $key "csi_attacher_latest_version" -}}v4.8.1
+{{- else if eq $key "csi_external_health_monitor_controller_latest_version" -}}v0.14.0
+{{- else if eq $key "csi_node_driver_registrar_latest_version" -}}v2.13.0
+{{- else if eq $key "csi_provisioner_latest_version" -}}v5.2.0
+{{- else if eq $key "csi_resizer_latest_version" -}}v1.13.2
 {{- else if eq $key "csi_snapshotter_latest_version" -}}v8.2.1
 {{- else if eq $key "metadata_retriever_latest_version" -}}v1.11.0
 {{- else if eq $key "volumegroup_snapshotter_latest_version" -}}v1.8.1


### PR DESCRIPTION
# Description
**Depends On:** https://github.com/dell/common-github-actions/pull/168

Adds the GitHub action to manually trigger and periodically update the CSI sidecars throughout the installation and CSM docs through the use of shortcodes.

The shortcodes syntax for the CSI sidecars to be more descriptive and better aligned to the naming convention of the tags. This change has been tested and ensured that the substitution still works as expected.

An example of the GitHub action running can be found: https://github.com/falfaroc/csm-docs/pull/10.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

