### PR TITLE
Fix broken link

### DIFF
--- a/content/docs/getting-started/installation/openshift/powermax/prerequisite/_index.md
+++ b/content/docs/getting-started/installation/openshift/powermax/prerequisite/_index.md
@@ -9,7 +9,7 @@ toc_hide: true
 
 ### CSI PowerMax Reverse Proxy
 
-The CSI PowerMax Reverse Proxy is a component that will be installed with the CSI PowerMax driver. For more details on this feature, see the related [documentation](../../../../../concepts/csidriver/features/powermax#csi-powermax-reverse-proxy).
+The CSI PowerMax Reverse Proxy is a component that is installed with the CSI PowerMax driver. For more details on this feature, see the related [documentation](../../../../../concepts/csidriver/features/powermax#csi-powermax-reverse-proxy).
 
 Create a TLS secret that holds an SSL certificate and a private key. This is required by the reverse proxy server.
 

--- a/content/docs/getting-started/installation/openshift/powermax/prerequisite/_index.md
+++ b/content/docs/getting-started/installation/openshift/powermax/prerequisite/_index.md
@@ -9,7 +9,7 @@ toc_hide: true
 
 ### CSI PowerMax Reverse Proxy
 
-The CSI PowerMax Reverse Proxy is a component that will be installed with the CSI PowerMax driver. For more details on this feature, see the related [documentation](../../../../../concepts/csidriver/features/powermax.md#csi-powermax-reverse-proxy).
+The CSI PowerMax Reverse Proxy is a component that will be installed with the CSI PowerMax driver. For more details on this feature, see the related [documentation](../../../../../concepts/csidriver/features/powermax#csi-powermax-reverse-proxy).
 
 Create a TLS secret that holds an SSL certificate and a private key. This is required by the reverse proxy server.
 


### PR DESCRIPTION
# Description
Fixed a broken link in PowerMax reverse-proxy information.
This PR is for live doc.
main/1.15 branch does not have this issue in docs and v1 versions.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1923 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

![Broken link fixed](https://github.com/user-attachments/assets/645bc15e-ddcc-48f6-9ee0-c508b26e8419)