### PR TITLE
Removed karavi namespace dependency from csm-operator for observability

### DIFF
--- a/content/docs/getting-started/installation/operator/modules/observability.md
+++ b/content/docs/getting-started/installation/operator/modules/observability.md
@@ -12,11 +12,6 @@ Install the Observability module for Dell CSI Drivers using the Container Storag
 
 ## Prerequisites
 
-Create a namespace `karavi`
-
-  ```bash
-  kubectl create namespace karavi
-  ```
   Enable the Observability module with the following configuration:
   
   ```yaml

--- a/content/docs/getting-started/installation/operator/openshift_modules/observability.md
+++ b/content/docs/getting-started/installation/operator/openshift_modules/observability.md
@@ -125,10 +125,11 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
    ```
 
    <br> 
-   
+
+  <ol>
+  {{< hide class="1" >}}
    Example:
-   <ol>
-   {{< hide class="1" >}}
+
    ```yaml 
    cat <<EOF> smon-otel-collector.yaml
    apiVersion: monitoring.coreos.com/v1
@@ -149,11 +150,21 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
          app.kubernetes.io/name: otel-collector 
     EOF
     ```  
-    {{< /hide >}} 
-    </ol>
+
+   Verify the ServiceMonitor is created. 
+
+    ```terminal
+    oc get smon -n isilon
+    NAME             AGE
+    otel-collector   44h 
+    ``` 
+  {{< /hide >}} 
+  </ol>
     
-       <ol>
-   {{< hide class="2" >}}
+  <ol>
+  {{< hide class="2" >}}
+   Example:
+
    ```yaml 
    cat <<EOF> smon-otel-collector.yaml
    apiVersion: monitoring.coreos.com/v1
@@ -173,26 +184,10 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
          app.kubernetes.io/instance: karavi-observability
          app.kubernetes.io/name: otel-collector 
     EOF
-    ```  
-    {{< /hide >}} 
-    </ol>
+    ``` 
 
    Verify the ServiceMonitor is created. 
 
-  <ol>
-  {{< hide class="1" >}}
-   ```yaml 
-    ```terminal
-    oc get smon -n isilon
-    NAME             AGE
-    otel-collector   44h 
-    ``` 
-  {{< /hide >}} 
-  </ol>
-
-  <ol>
-  {{< hide class="1" >}}
-   ```yaml 
     ```terminal
     oc get smon -n vxflexos
     NAME             AGE
@@ -200,7 +195,7 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
     ``` 
   {{< /hide >}} 
   </ol>
-  
+
 6. Verify the PowerFlex metrics are visible in the OpenShift Console. 
 
    On the OpenShift Console, navigate to Observer and then Metrics, search for PowerFlex metric.

--- a/content/docs/getting-started/installation/operator/openshift_modules/observability.md
+++ b/content/docs/getting-started/installation/operator/openshift_modules/observability.md
@@ -13,16 +13,7 @@ description: >
 
 <br>
 
-3. Create a Project for deploying Observability Module 
-   
- 
-
-   Use this command to create new project. You must use the project name as karavi  
-   ```bash
-   oc new-project karavi 
-   ```
-
-4. Enable Observability module in the CSM  
+3. Enable Observability module in the CSM  
    
 
    Use this command to create the **ContainerStorageModule** custom resource with Observability enabled.
@@ -62,7 +53,7 @@ description: >
 {{< hide class="1" >}}
 
 ```terminal
-oc get pod -n karavi
+oc get pod -n isilon
 
 NAME                                         READY   STATUS    RESTARTS   AGE
 karavi-metrics-powerscale-69855dbdd5-5mshq   1/1     Running   0          2m54s
@@ -75,7 +66,7 @@ otel-collector-b496d8c4d-gp6zz               2/2     Running   0          2m55s
 {{< hide class="2" >}}
 
 ```terminal
-oc get pod -n karavi
+oc get pod -n vxflexos
 
 NAME                                         READY   STATUS    RESTARTS   AGE
 karavi-metrics-powerflex-69855dbdd5-5mshq    1/1     Running   0          2m54s
@@ -98,7 +89,7 @@ Verify the Observability Services.
 {{< hide class="1" >}}
 
 ```terminal 
-oc get svc -n karavi
+oc get svc -n isilon
 NAME                           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
 karavi-metrics-powerscale      ClusterIP   172.30.169.86    <none>        2222/TCP             3m29s
 karavi-topology                ClusterIP   172.30.66.155    <none>        8443/TCP             3m29s
@@ -113,7 +104,7 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
 {{< hide class="2" >}}
 
  ```terminal 
- oc get svc -n karavi
+ oc get svc -n vxflexos
  NAME                           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)              AGE
  karavi-metrics-powerflex       ClusterIP   172.30.169.86    <none>        2222/TCP             3m29s
  karavi-topology                ClusterIP   172.30.66.155    <none>        8443/TCP             3m29s
@@ -136,13 +127,15 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
    <br> 
    
    Example:
+   <ol>
+   {{< hide class="1" >}}
    ```yaml 
    cat <<EOF> smon-otel-collector.yaml
    apiVersion: monitoring.coreos.com/v1
    kind: ServiceMonitor
    metadata:
      name: otel-collector
-     namespace: karavi
+     namespace: isilon
    spec:
      endpoints:
      - path: /metrics
@@ -156,15 +149,58 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
          app.kubernetes.io/name: otel-collector 
     EOF
     ```  
+    {{< /hide >}} 
+    </ol>
+    
+       <ol>
+   {{< hide class="2" >}}
+   ```yaml 
+   cat <<EOF> smon-otel-collector.yaml
+   apiVersion: monitoring.coreos.com/v1
+   kind: ServiceMonitor
+   metadata:
+     name: otel-collector
+     namespace: vxflexos
+   spec:
+     endpoints:
+     - path: /metrics
+       port: exporter-https
+       scheme: https
+       tlsConfig:
+         insecureSkipVerify: true
+     selector:
+       matchLabels:
+         app.kubernetes.io/instance: karavi-observability
+         app.kubernetes.io/name: otel-collector 
+    EOF
+    ```  
+    {{< /hide >}} 
+    </ol>
 
    Verify the ServiceMonitor is created. 
 
+  <ol>
+  {{< hide class="1" >}}
+   ```yaml 
     ```terminal
-    oc get smon -n karavi
+    oc get smon -n isilon
     NAME             AGE
     otel-collector   44h 
     ``` 
+  {{< /hide >}} 
+  </ol>
 
+  <ol>
+  {{< hide class="1" >}}
+   ```yaml 
+    ```terminal
+    oc get smon -n vxflexos
+    NAME             AGE
+    otel-collector   44h 
+    ``` 
+  {{< /hide >}} 
+  </ol>
+  
 6. Verify the PowerFlex metrics are visible in the OpenShift Console. 
 
    On the OpenShift Console, navigate to Observer and then Metrics, search for PowerFlex metric.

--- a/content/docs/getting-started/installation/operator/openshift_modules/observability.md
+++ b/content/docs/getting-started/installation/operator/openshift_modules/observability.md
@@ -125,11 +125,9 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
    ```
 
    <br> 
-
-  <ol>
-  {{< hide class="1" >}}
+   
    Example:
-
+   {{< hide class="1" >}}
    ```yaml 
    cat <<EOF> smon-otel-collector.yaml
    apiVersion: monitoring.coreos.com/v1
@@ -149,23 +147,11 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
          app.kubernetes.io/instance: karavi-observability
          app.kubernetes.io/name: otel-collector 
     EOF
-    ```  
+   ```  
+   {{< /hide >}} 
 
-   Verify the ServiceMonitor is created. 
-
-    ```terminal
-    oc get smon -n isilon
-    NAME             AGE
-    otel-collector   44h 
-    ``` 
-  {{< /hide >}} 
-  </ol>
-    
-  <ol>
   {{< hide class="2" >}}
-   Example:
-
-   ```yaml 
+  ```yaml 
    cat <<EOF> smon-otel-collector.yaml
    apiVersion: monitoring.coreos.com/v1
    kind: ServiceMonitor
@@ -184,17 +170,36 @@ otel-collector                 ClusterIP   172.30.127.237   <none>        55680/
          app.kubernetes.io/instance: karavi-observability
          app.kubernetes.io/name: otel-collector 
     EOF
-    ``` 
-
-   Verify the ServiceMonitor is created. 
-
-    ```terminal
-    oc get smon -n vxflexos
-    NAME             AGE
-    otel-collector   44h 
-    ``` 
+  ```  
   {{< /hide >}} 
-  </ol>
+
+<ol>
+
+Verify the ServiceMonitor is created. 
+
+{{< hide class="1" >}}
+
+```terminal 
+oc get smon -n isilon
+NAME             AGE
+otel-collector   44h 
+``` 
+
+{{< /hide >}} 
+
+</ol> 
+
+<ol>
+{{< hide class="2" >}}
+
+ ```terminal 
+oc get smon -n vxflexos
+NAME             AGE
+otel-collector   44h 
+ ``` 
+
+{{< /hide >}}
+</ol>
 
 6. Verify the PowerFlex metrics are visible in the OpenShift Console. 
 


### PR DESCRIPTION
# Description
PR to remove karavi namespace dependency  from documentation. 
Linked PR: https://github.com/dell/csm-operator/pull/1027

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896|

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

<img width="659" alt="image" src="https://github.com/user-attachments/assets/bb9721b5-ea9a-4d77-9a7d-1df48c6c72ab" />
<img width="617" alt="image" src="https://github.com/user-attachments/assets/91e23f7b-4652-4763-9ee2-ce7f2b31f4e2" />
<img width="796" alt="image" src="https://github.com/user-attachments/assets/e37386e1-e54a-4258-9c27-589f4ae61d67" />
<img width="592" alt="image" src="https://github.com/user-attachments/assets/09de7138-74c8-426f-9b23-6da52b96f0e9" />

<img width="673" alt="image" src="https://github.com/user-attachments/assets/a3927829-9d10-4d43-8f78-4e40b63c0536" />

