### PR TITLE
Fix indentation of cron jon for sidecar action

### DIFF
--- a/.github/workflows/csi-sidecars-update.yaml
+++ b/.github/workflows/csi-sidecars-update.yaml
@@ -10,7 +10,7 @@ name: Update CSI Sidecars
 
 on:
   workflow_dispatch:  # Allows manual trigger
-    schedule:
+  schedule:
     - cron: '0 0 * * 3'  # Runs every Wednesday at Midnight
 
 jobs:


### PR DESCRIPTION
# Description
Fix the formatting of the csi sidecar update action. This was causing it to not run periodically.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

