### PR TITLE
Renaming powerscale secret name from isilon-config to isilon-creds

### DIFF
--- a/content/docs/getting-started/installation/openshift/powerscale/csmoperator/_index.md
+++ b/content/docs/getting-started/installation/openshift/powerscale/csmoperator/_index.md
@@ -193,10 +193,10 @@ dell-csm-operator-controller-manager-86dcdc8c48-6dkxm      2/2     Running      
  
     <br>
 
-    Edit the file, then run the command to create the `isilon-config`.
+    Edit the file, then run the command to create the `isilon-creds`.
 
     ```bash
-    oc create secret generic isilon-config --from-file=config=config.yaml -n isilon --dry-run=client -oyaml > secret-isilon-config.yaml
+    oc create secret generic isilon-creds --from-file=config=config.yaml -n isilon --dry-run=client -oyaml > secret-isilon-config.yaml
     ```
     
     Use this command to **create** the config:
@@ -269,7 +269,7 @@ dell-csm-operator-controller-manager-86dcdc8c48-6dkxm      2/2     Running      
       driver:
         csiDriverType: "isilon"
         configVersion: {{< version-docs key="PScale_latestVersion" >}}
-        authSecret: isilon-config
+        authSecret: isilon-creds
         common:
           envs:
             - name: X_CSI_ISI_AUTH_TYPE

--- a/content/v1/getting-started/installation/openshift/powerscale/csmoperator/_index.md
+++ b/content/v1/getting-started/installation/openshift/powerscale/csmoperator/_index.md
@@ -193,10 +193,10 @@ dell-csm-operator-controller-manager-86dcdc8c48-6dkxm      2/2     Running      
  
     <br>
 
-    Edit the file, then run the command to create the `isilon-config`.
+    Edit the file, then run the command to create the `isilon-creds`.
 
     ```bash
-    oc create secret generic isilon-config --from-file=config=config.yaml -n isilon --dry-run=client -oyaml > secret-isilon-config.yaml
+    oc create secret generic isilon-creds --from-file=config=config.yaml -n isilon --dry-run=client -oyaml > secret-isilon-config.yaml
     ```
     
     Use this command to **create** the config:
@@ -269,7 +269,7 @@ dell-csm-operator-controller-manager-86dcdc8c48-6dkxm      2/2     Running      
       driver:
         csiDriverType: "isilon"
         configVersion: {{< version-v1 key="PScale_latestVersion" >}}
-        authSecret: isilon-config
+        authSecret: isilon-creds
         common:
           envs:
             - name: X_CSI_ISI_AUTH_TYPE


### PR DESCRIPTION
# Description
To rename secret for powerscale as isilon-creds in documentation for ocp environment. It should be isilon-creds instead of isilon-config.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1955 |

# Checklist:

- [X] Have you run a grammar and spell checks against your submission?
- [X] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

<img width="965" height="198" alt="image" src="https://github.com/user-attachments/assets/05aa6996-af3f-4635-ba3e-42de5afe001c" />

