### PR TITLE
Use full path links in Authorization Install page

### DIFF
--- a/content/docs/getting-started/installation/helm/modules/authorizationv2-0.md
+++ b/content/docs/getting-started/installation/helm/modules/authorizationv2-0.md
@@ -302,23 +302,23 @@ helm -n authorization install authorization -f myvalues.yaml charts/csm-authoriz
 
 >__Note__: Karavictl will not work with Authorization v2.x. Please use dellctl instead.
 
-Follow the instructions for [Installing dellctl](docs/tooling/cli/#installation-instructions).
+Follow the instructions for [Installing dellctl](../../../../docs/tooling/cli/#installation-instructions).
 
 ## Configuring the Authorization Proxy Server
 
-Follow the instructions available in Authorization for [Configuring the Authorization Proxy Server](docs/concepts/authorization/v2.x/configuration/).
+Follow the instructions available in Authorization for [Configuring the Authorization Proxy Server](../../../../docs/concepts/authorization/v2.x/configuration/).
 
 ## Configuring a Dell CSI Driver with Container Storage Modules for Authorization
 
 Follow the instructions available in Authorization for
 
-{{< hide id="1" >}} - [Configuring PowerFlex with Authorization](docs/concepts/authorization/v2.x/configuration/powerflex). {{< /hide >}}
+{{< hide id="1" >}} - [Configuring PowerFlex with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powerflex). {{< /hide >}}
 
-{{< hide id="2" >}}- [Configuring PowerMax with Authorization](docs/concepts/authorization/v2.x/configuration/powermax).{{< /hide >}}
+{{< hide id="2" >}}- [Configuring PowerMax with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powermax).{{< /hide >}}
 
-{{< hide id="3" >}}- [Configuring PowerScale with Authorization](docs/concepts/authorization/v2.x/configuration/powerscale).{{< /hide >}}
+{{< hide id="3" >}}- [Configuring PowerScale with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powerscale).{{< /hide >}}
 
-{{< hide id="3" >}}- [Configuring PowerStore with Authorization](docs/concepts/authorization/v2.x/configuration/powerstore).{{< /hide >}}
+{{< hide id="3" >}}- [Configuring PowerStore with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powerstore).{{< /hide >}}
 
 ## Updating Container Storage Modules for Authorization Proxy Server Configuration
 

--- a/content/docs/getting-started/installation/operator/modules/authorizationv2-0.md
+++ b/content/docs/getting-started/installation/operator/modules/authorizationv2-0.md
@@ -269,21 +269,21 @@ Once the Authorization CR is created, you can verify the installation as mention
 
 >__Note__: Karavictl will not work with Authorization v2.x. Please use dellctl instead.
 
-Follow the instructions for [Installing dellctl](docs/tooling/cli/#installation-instructions).
+Follow the instructions for [Installing dellctl](../../../../docs/tooling/cli/#installation-instructions).
 
 ### Configure the Container Storage Modules Authorization Proxy Server
 
-Follow the instructions available in Authorization for [Configuring the Authorization Proxy Server](docs/concepts/authorization/v2.x/configuration/).
+Follow the instructions available in Authorization for [Configuring the Authorization Proxy Server](../../../../docs/concepts/authorization/v2.x/configuration/).
 
 ### Configure a Dell CSI Driver with Container Storage Modules Authorization
 
 Follow the instructions available in Authorization for
 
-{{< hide id="1" >}}- [Configuring PowerFlex with Authorization](docs/concepts/authorization/v2.x/configuration/powerflex).{{< /hide >}}
+{{< hide id="1" >}}- [Configuring PowerFlex with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powerflex).{{< /hide >}}
 
-{{< hide id="2" >}}- [Configuring PowerMax with Authorization](docs/concepts/authorization/v2.x/configuration/powermax).{{< /hide >}}
+{{< hide id="2" >}}- [Configuring PowerMax with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powermax).{{< /hide >}}
 
-{{< hide id="3" >}}- [Configuring PowerScale with Authorization](docs/concepts/authorization/v2.x/configuration/powerscale).{{< /hide >}}
+{{< hide id="3" >}}- [Configuring PowerScale with Authorization](../../../../docs/concepts/authorization/v2.x/configuration/powerscale).{{< /hide >}}
 
 ## Vault CSI Provider Installation
 


### PR DESCRIPTION
# Description

In the Authorization V2 installation pages for Helm and Operator, use the full path to other pages. 

Before:
`Follow the instructions for [Installing dellctl](docs/tooling/cli/#installation-instructions).`

Now:
`Follow the instructions for [Installing dellctl](../../../../docs/tooling/cli/#installation-instructions).`

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1468 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

