### PR TITLE
Update PowerFlex version references for CSM 1.14.1

### DIFF
--- a/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.14.1-values.template
+++ b/content/docs/getting-started/installation/installationwizard/src/templates/helm/csm-1.14.1-values.template
@@ -245,11 +245,11 @@ csi-powermax:
 ##########################################
 csi-vxflexos:
   enabled: $POWERFLEX_ENABLED
-  version: v2.14.0
+  version: v2.14.1
   images:
     # "driver" defines the container image, used for the driver container.
     driver: 
-      image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.14.0
+      image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.14.1
     # "powerflexSdc" defines the SDC image for init container.
     powerflexSdc: 
       image: dellemc/sdc:4.5.4

--- a/content/docs/getting-started/installation/kubernetes/powerflex/helm/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powerflex/helm/_index.md
@@ -175,7 +175,7 @@ Use the below command to replace or update the secret:
 
 7. Download the default values.yaml file
    ```bash
-   cd dell-csi-helm-installer && wget -O myvalues.yaml https://github.com/dell/helm-charts/raw/csi-vxflexos-2.14.0/charts/csi-vxflexos/values.yaml
+   cd dell-csi-helm-installer && wget -O myvalues.yaml https://github.com/dell/helm-charts/raw/csi-vxflexos-2.14.1/charts/csi-vxflexos/values.yaml
    ```
 
 8. If you are using custom images, check the fields under `images` in `my-vxflexos-settings.yaml` to make sure that they are pointing to the correct image repository.

--- a/content/docs/release/_index.md
+++ b/content/docs/release/_index.md
@@ -73,6 +73,7 @@ Description: >
 - [#1930 - [BUG]: Powerstore has unnecessary sharedNFS related codes that affects performance](https://github.com/dell/csm/issues/1930)
 - [#1942 - [BUG]: NVMe/TCP mounts fail on OCP 4.19/RHEL 9.6 having NVMe CLI v2.11.0](https://github.com/dell/csm/issues/1939)
 - [#1957 - [BUG]: Powermax NVMe volumes not reattached after pod deletion](https://github.com/dell/csm/issues/1957)
+- [#1956 - [BUG]: Make probe-retry in Powerflex driver configurable](https://github.com/dell/csm/issues/1956)
 
 
 ### Known Issues

--- a/layouts/shortcodes/version-docs.html
+++ b/layouts/shortcodes/version-docs.html
@@ -1,5 +1,5 @@
 {{- $key := .Get "key" -}}
-{{- if eq $key "PFlex_latestVersion" -}}v2.14.0
+{{- if eq $key "PFlex_latestVersion" -}}v2.14.1
 {{- else if eq $key "PFlex_preVersion" -}}v2.13.0
 {{- else if eq $key "PStore_latestVersion" -}}v2.14.1
 {{- else if eq $key "PStore_preVersion" -}}v2.13.0


### PR DESCRIPTION
# Description
Update PowerFlex version references to ensure that the correct version is in different locations.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1942 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

# Results
- [x] Ensure that Installation Wizard points to the v2.14.1 version of PowerFlex.
```
## K8S/CSI-PowerFlex ATTRIBUTES
##########################################
csi-vxflexos:
  enabled: true
  version: v2.14.1
  images:
    # "driver" defines the container image, used for the driver container.
    driver: 
      image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.14.1
```