### PR TITLE
Support condensed secret for authorization sidecar

### DIFF
--- a/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
@@ -19,29 +19,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
    This takes the assumption that Powerflex will be installed in the `vxflexos` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in the [CSI PowerFlex](https://github.com/dell/csi-powerflex/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-{{< collapse id="1" title="Parameters">}}
-   | Parameter                 | Description                                                                                                      | Required | Default                        |
-   | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
-   | username                  | Username for connecting to the backend storage array. This parameter is ignored.                                 | No       | -                              |
-   | password                  | Password for connecting to to the backend storage array. This parameter is ignored.                              | No       | -                              |
-   | intendedEndpoint          | HTTPS REST API endpoint of the backend storage array.                                                            | Yes      | -                              |
-   | endpoint                  | HTTPS localhost endpoint that the authorization sidecar will listen on.                                          | Yes      | https://localhost:9400         |
-   | systemID                  | System ID of the backend storage array.                                                                          | Yes      | " "                            |
-   | skipCertificateValidation | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No       | true                           |
-   | isDefault                 | A boolean that indicates if the array is the default array. This parameter is not used.                          | No       | default value from values.yaml |
-{{< /collapse >}}
-<ul style="list-style-type: none;">
-<li>Create the karavi-authorization-config secret using this command:
-
-  ```bash
-    kubectl -n vxflexos create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-  ```
-</li>
-</ul>
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -55,13 +33,13 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       kubectl -n vxflexos create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
 
     **Operator**
 
     Refer to the [Create Secret](../../../../../getting-started/installation/kubernetes/powerflex/csmoperator/#create-secret) section to prepare `secret.yaml` to configure the driver to communicate with the Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -83,7 +61,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerflex/helm/#install-driver) section to edit the parameters in `samples/config.yaml` to configure the driver to communicate with Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -101,7 +79,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       mdm: "10.0.0.3,10.0.0.4"
     ```
 
-5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
   Alternatively, you can use the minimal sample files provided in respective CSM versions folder under samples [here](https://github.com/dell/csm-operator/tree/main/samples) and install the module using default value.
 
     **Operator**

--- a/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
@@ -20,25 +20,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
    This takes the assumption that PowerScale will be installed in the `isilon` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in [CSI PowerScale](https://github.com/dell/csi-powerscale/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-  | Parameter                 | Description                                                                                                      | Required | Default                        |
-  | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
-  | username                  | Username for connecting to the backend storage array. This parameter is ignored.                                 | No       | -                              |
-  | password                  | Password for connecting to to the backend storage array. This parameter is ignored.                              | No       | -                              |
-  | intendedEndpoint          | HTTPS REST API endpoint of the backend storage array.                                                            | Yes      | -                              |
-  | endpoint                  | HTTPS localhost endpoint that the authorization sidecar will listen on.                                          | Yes      | https://localhost:9400         |
-  | systemID                  | Cluster name of the backend storage array.                                                                       | Yes      | " "                            |
-  | skipCertificateValidation | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No       | true                           |
-  | isDefault                 | A boolean that indicates if the array is the default array. This parameter is not used.                          | No       | default value from values.yaml |
-
-  Create the karavi-authorization-config secret using this command:
-
-  ```bash
-  kubectl -n isilon create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-  ```
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -52,13 +34,13 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
       kubectl -n isilon create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with Authorization sidecar.
 
     **Operator**
 
     Refer to the [Prerequisite](../../../../../getting-started/installation/kubernetes/powerscale/csmoperator/#install-driver) section to prepare the `secret.yaml` file to configure the driver to communicate with the CSM Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `mountEndpoint` to the PowerScale OneFS API server. For example, 10.0.0.1.
 
@@ -84,7 +66,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerscale/helm/#install-driver) section to edit the parameters to prepare the `samples/secret/secret.yaml` file to configure the driver to communicate with Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `mountEndpoint` to the PowerScale OneFS API server. For example, 10.0.0.1.
 
@@ -106,7 +88,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         skipCertificateValidation: true
     ```
 
-5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
 
     **Operator**
 
@@ -177,4 +159,4 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
       skipCertificateValidation: true
     ```
 
-6. Install the Dell CSI PowerScale driver following the appropriate documentation for your installation method.
+5. Install the Dell CSI PowerScale driver following the appropriate documentation for your installation method.

--- a/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
@@ -19,29 +19,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
    This takes the assumption that PowerStore will be installed in the `powerstore` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in the [CSI PowerStore](https://github.com/dell/csi-powerstore/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-{{< collapse id="1" title="Parameters">}}
-   | Parameter                 | Description                                                                                                      | Required | Default                        |
-   | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
-   | username                  | Username for connecting to the backend storage array. This parameter is ignored.                                 | No       | -                              |
-   | password                  | Password for connecting to to the backend storage array. This parameter is ignored.                              | No       | -                              |
-   | intendedEndpoint          | HTTPS REST API endpoint of the backend storage array.                                                            | Yes      | -                              |
-   | endpoint                  | HTTPS localhost endpoint that the authorization sidecar will listen on.                                          | Yes      | https://localhost:9400         |
-   | systemID                  | System ID of the backend storage array.                                                                          | Yes      | " "                            |
-   | skipCertificateValidation | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No       | true                           |
-   | isDefault                 | A boolean that indicates if the array is the default array. This parameter is not used.                          | No       | default value from values.yaml |
-{{< /collapse >}}
-<ul style="list-style-type: none;">
-<li>Create the karavi-authorization-config secret using this command:
-
-  ```bash
-    kubectl -n powerstore create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-  ```
-</li>
-</ul>
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -55,13 +33,13 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       kubectl -n powerstore create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
 
     **Operator**
 
     Refer to the [Create Secret](../../../../../getting-started/installation/kubernetes/powerstore/csmoperator/#create-secret) section to prepare `secret.yaml` to configure the driver to communicate with the Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -80,7 +58,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerstore/helm/#install-driver) section to edit the parameters in `samples/config.yaml` to configure the driver to communicate with Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -95,7 +73,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       isDefault: true
     ```
 
-5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
   Alternatively, you can use the minimal sample files provided in respective CSM versions folder under samples [here](https://github.com/dell/csm-operator/tree/main/samples) and install the module using default value.
 
     **Operator**
@@ -142,7 +120,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     - Update `authorization.enabled` to `true`.
 
-    - Update `images.authorization` to the image of Authorization sidecar. 
+    - Update `images.authorization` to the image of Authorization sidecar.
 
     - Update `authorization.proxyHost` to the hostname of Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of Authorization for the correct value.
 


### PR DESCRIPTION
# Description
PR updates the authorization sidecar steps to support the driver secret to connect to the proxy server, instead of needing the karavi-authorization-config secret.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1583 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

