### PR TITLE
Be explicit with replication group names

### DIFF
--- a/content/docs/concepts/replication/disaster-recovery.md
+++ b/content/docs/concepts/replication/disaster-recovery.md
@@ -14,11 +14,23 @@ Once the `DellCSIReplicationGroup` & `PersistentVolume` objects have been replic
 This scenario is the typical choice when you want to try your disaster recovery plan or you need to switch activities from one site to another: 
 
 a. Execute "failover" action on selected ReplicationGroup using the cluster name
-    
+   On a stretched Kubernetes cluster:
+   ```bash
+   ./repctl failover --rg rg-id-site-1 --target rg-id-site-2
+   ```
+
+   With two Kubernetes clusters:
    ```bash
     ./repctl --rg rg-id failover --target target-cluster-name
-   ```    
+   ```
+
 b. Execute "reprotect" action on selected ReplicationGroup which will resume the replication from new "source"
+   On a stretched Kubernetes cluster:
+   ```bash
+   ./repctl reprotect --rg rg-id-site-2
+   ```
+
+   With two Kubernetes clusters:
    ```bash
     ./repctl --rg rg-id reprotect --at new-source-cluster-name
    ```
@@ -27,18 +39,36 @@ b. Execute "reprotect" action on selected ReplicationGroup which will resume the
 ### Unplanned Migration to the target cluster/array
 This scenario is the typical choice when a site goes down: 
 
-a. Execute "failover" action on selected ReplicationGroup using the cluster name 
-   ```bash    
+a. Execute "failover" action on selected ReplicationGroup using the cluster name
+   On a stretched Kubernetes cluster:
+   ```bash
+   ./repctl failover --rg rg-id-site-1 --target rg-id-site-2 --unplanned
+   ```
+
+   With two Kubernetes clusters:
+   ```bash
     ./repctl --rg rg-id failover --target target-cluster-name --unplanned 
    ```    
 b. Execute "swap" action on selected ReplicationGroup which would swap personalities of R1 and R2 (only applicable for PowerMax driver)
+   On a stretched Kubernetes cluster:
+   ```bash
+    ./repctl --rg rg-id-site-2 swap
+   ```
+
+   With two Kubernetes clusters:
    ```bash    
     ./repctl --rg rg-id swap --at target-cluster-name
    ```
 > _**Note**_: Unplanned migration usually happens when the original "source" cluster is unavailable. The following action makes sense when the cluster is back.
 
 c. Execute "reprotect" action on selected ReplicationGroup which will resume the replication.
+   On a stretched Kubernetes cluster:
    ```bash    
+    ./repctl --rg rg-id-site-1 reprotect
+   ```
+
+   With two Kubernetes clusters:
+   ```bash
     ./repctl --rg rg-id reprotect --at new-source-cluster-name
    ```        
 ![state_changes2](../../../../images/replication/state_changes2.png) 


### PR DESCRIPTION
# Description
The commands for `repctl` are different if we are on a stretched k8s cluster or multiple ones.

This modification tries to be more explicit of the source and target in case of stretched cluster

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| 1902 |

# Checklist:

- [ ] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

