### PR TITLE
Updated Virtualization Support & Other Fixes

### DIFF
--- a/content/docs/getting-started/installation/kubernetes/powerscale/csmoperator/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powerscale/csmoperator/_index.md
@@ -80,7 +80,7 @@ To deploy the Operator, follow the instructions available [here](../../../operat
 
 4. **Install Driver**
 
-   i. **Create a CR (Custom Resource)** for PowerFlex using the sample files provided
+   i. **Create a CR (Custom Resource)** for PowerScale using the sample files provided
 
     a. **Minimal Configuration:**
       ```yaml

--- a/content/docs/getting-started/installation/operator/operatorinstallation_kubernetes.md
+++ b/content/docs/getting-started/installation/operator/operatorinstallation_kubernetes.md
@@ -30,7 +30,7 @@ Before installing the driver, you need to install the operator. You can find the
 git clone -b {{< version-docs key="csm-operator_latest_version" >}} https://github.com/dell/csm-operator.git
 ```
 3. `cd csm-operator`
-4. _(Optional)_ If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
+4. _(Optional)_ If using a local image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
 5. _(Optional)_ The Container Storage Modules Operator might need more resources if users have larger environment (>1000 Pods). You can modify the default resource requests and limits in the files `deploy/operator.yaml`, `config/manager/manager.yaml`  and increase the values for cpu and memory. More information on setting the resource requests and limits can be found [here](https://sdk.operatorframework.io/docs/best-practices/managing-resources/). Current default values are set as below:
     ```yaml
         resources:

--- a/content/v1/getting-started/installation/operator/operatorinstallation_kubernetes.md
+++ b/content/v1/getting-started/installation/operator/operatorinstallation_kubernetes.md
@@ -30,7 +30,7 @@ Before installing the driver, you need to install the operator. You can find the
 git clone -b {{< version-v1 key="csm-operator_latest_version" >}} https://github.com/dell/csm-operator.git
 ```
 3. `cd csm-operator`
-4. _(Optional)_ If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
+4. _(Optional)_ If using a local image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
 5. _(Optional)_ The Container Storage Modules Operator might need more resources if users have larger environment (>1000 Pods). You can modify the default resource requests and limits in the files `deploy/operator.yaml`, `config/manager/manager.yaml`  and increase the values for cpu and memory. More information on setting the resource requests and limits can be found [here](https://sdk.operatorframework.io/docs/best-practices/managing-resources/). Current default values are set as below:
     ```yaml
         resources:

--- a/content/v1/supportmatrix/_index.md
+++ b/content/v1/supportmatrix/_index.md
@@ -44,10 +44,10 @@ weight: 1
 {{<table "table table-striped table-bordered table-sm">}}
 | Version | Capability               | PowerFlex | PowerMax | PowerStore | PowerScale | Unity |
 |---------|--------------------------| :-------: | :------: | :--------: | :--------: | :---: |
-| 4.18 - 4.19    |  <div style="text-align: left"> [Storage](https://github.com/kiagnose/kubevirt-storage-checkup) </div> | Yes       | Yes      | Yes        | Yes        | No    |
-| 4.18 - 4.19   | <div style="text-align: left">  Observability        </div>   | Yes       | Yes      | No         | Yes        | No    |
-| 4.18 - 4.19    | <div style="text-align: left"> Authorization - v2.x  </div>   | Yes       | Yes      | No         | Yes        | No    |
-| 4.18 - 4.19   | <div style="text-align: left"> Resiliency            </div>   | Yes       | Yes      | Yes         | Yes        | No    |
+| 4.18 - 4.19    |  <div style="text-align: left"> [Storage](https://github.com/kiagnose/kubevirt-storage-checkup) </div> | Yes       | Yes      | Yes        | No        | No    |
+| 4.18 - 4.19   | <div style="text-align: left">  Observability        </div>   | Yes       | Yes      | No         | No        | No    |
+| 4.18 - 4.19    | <div style="text-align: left"> Authorization - v2.x  </div>   | Yes       | Yes      | Yes        | No        | No    |
+| 4.18 - 4.19   | <div style="text-align: left"> Resiliency            </div>   | Yes       | Yes      | Yes         | No        | No    |
 | 4.18 - 4.19    | <div style="text-align: left"> Replication (Metro)	</div>   | No       | Yes      | Yes         | No        | No    |
 {{</table>}}
 

--- a/content/v2/deployment/csmoperator/_index.md
+++ b/content/v2/deployment/csmoperator/_index.md
@@ -75,7 +75,7 @@ Both editions have the same codebase and are supported by Dell Technologies, the
 git clone -b v1.8.1 https://github.com/dell/csm-operator.git
 ```
 3. `cd csm-operator`
-4. _(Optional)_ If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
+4. _(Optional)_ If using a local image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
 5. _(Optional)_ The Dell CSM Operator might need more resources if users have larger environment (>1000 Pods). You can modify the default resource requests and limits in the files `deploy/operator.yaml`, `config/manager/manager.yaml`  and increase the values for cpu and memory. More information on setting the resource requests and limits can be found [here](https://sdk.operatorframework.io/docs/best-practices/managing-resources/). Current default values are set as below:
     ```yaml
         resources:

--- a/content/v3/deployment/csmoperator/_index.md
+++ b/content/v3/deployment/csmoperator/_index.md
@@ -72,7 +72,7 @@ Both editions have the same codebase and are supported by Dell Technologies, the
 git clone -b v1.7.0 https://github.com/dell/csm-operator.git
 ```
 3. `cd csm-operator`
-4. _(Optional)_ If using a local Docker image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
+4. _(Optional)_ If using a local image, edit the `deploy/operator.yaml` file and set the image name for the CSM Operator Deployment.
 5. _(Optional)_ The Dell CSM Operator might need more resources if users have larger environment (>1000 Pods). You can modify the default resource requests and limits in the files `deploy/operator.yaml`, `config/manager/manager.yaml`  and increase the values for cpu and memory. More information on setting the resource requests and limits can be found [here](https://sdk.operatorframework.io/docs/best-practices/managing-resources/). Current default values are set as below:
     ```yaml
         resources:

--- a/layouts/shortcodes/version-docs.html
+++ b/layouts/shortcodes/version-docs.html
@@ -1,14 +1,14 @@
 {{- $key := .Get "key" -}}
-{{- if eq $key "PFlex_latestVersion" -}}v2.14.0
-{{- else if eq $key "PFlex_preVersion" -}}v2.13.0
+{{- if eq $key "PFlex_latestVersion" -}}v2.15.0
+{{- else if eq $key "PFlex_preVersion" -}}v2.14.0
 {{- else if eq $key "PStore_latestVersion" -}}v2.15.0
 {{- else if eq $key "PStore_preVersion" -}}v2.14.0
-{{- else if eq $key "PMax_latestVersion" -}}v2.14.0
-{{- else if eq $key "PMax_preVersion" -}}v2.13.0
-{{- else if eq $key "PScale_latestVersion" -}}v2.14.0
-{{- else if eq $key "PScale_preVersion" -}}v2.13.0
-{{- else if eq $key "PUnity_latestVersion" -}}v2.14.0
-{{- else if eq $key "PUnity_preVersion" -}}v2.13.0
+{{- else if eq $key "PMax_latestVersion" -}}v2.15.0
+{{- else if eq $key "PMax_preVersion" -}}v2.14.0
+{{- else if eq $key "PScale_latestVersion" -}}v2.15.0
+{{- else if eq $key "PScale_preVersion" -}}v2.14.0
+{{- else if eq $key "PUnity_latestVersion" -}}v2.15.0
+{{- else if eq $key "PUnity_preVersion" -}}v2.14.0
 {{- else if eq $key "cert_csi" -}}v1.8.0
 {{- else if eq $key "Observability_csm_topology_image" -}}v1.12.0
 {{- else if eq $key "Observability_csm_metrics_PStore_image" -}}v1.12.0
@@ -49,8 +49,8 @@
 {{- else if eq $key "sample_sc_pstore" -}}v2150
 {{- else if eq $key "sample_sc_pscale" -}}v2150
 {{- else if eq $key "sample_sc_unity" -}}v2140
-{{- else if eq $key "csm-operator_latest_samples_dir" -}}v2.15.0
-{{- else if eq $key "csm-operator_latest_version" -}}v1.9.0
+{{- else if eq $key "csm-operator_latest_samples_dir" -}}v2.15.0 
+{{- else if eq $key "csm-operator_latest_version" -}}v1.10.0
 {{- else if eq $key "csi_attacher_latest_version" -}}v4.9.0
 {{- else if eq $key "csi_external_health_monitor_controller_latest_version" -}}v0.15.0
 {{- else if eq $key "csi_node_driver_registrar_latest_version" -}}v2.14.0


### PR DESCRIPTION
# Description

- Fixed incorrect reference to PowerFlex → PowerScale in CR creation step.
- Updated optional step description: `If using a local Docker image` → `If using a local image` for better accuracy.
- Corrected Virtualization support for PowerScale in versions 4.18–4.19: Yes → No.
-  Corrected Virtualization support for PowerStore Auth in versions 4.18–4.19:  No → Yes.


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [x] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

