### PR TITLE
Revert "Warning Message - Too Long Contexts  (#1652)"

### DIFF
--- a/content/docs/concepts/csidriver/troubleshooting/powerstore.md
+++ b/content/docs/concepts/csidriver/troubleshooting/powerstore.md
@@ -22,5 +22,4 @@ description: Troubleshooting PowerStore Driver
 | Unable to install or upgrade the driver due to minimum Kubernetes version or Openshift version | Currently CSM only supports n, n-1, n-2 version of Kubernetes and Openshift, if you still wanted to continue with existing version update the `verify.sh` to continue.| 
 | Volumes are not getting deleted on the array when PV's are deleted | Ensure `persistentVolumeReclaimPolicy` is set to Delete. |
 | fsGroupPolicy may not work as expected without root privileges for NFS only [https://github.com/kubernetes/examples/issues/260](https://github.com/kubernetes/examples/issues/260) | To get the desired behavior set “RootClientEnabled” = “true” in the storage class parameter |
-| Volume mounts fail with "exceeds size limit" error | Due to a Kubernetes limitation, volume publish contexts are limited in size to 4kb or less. Having too many ISCSI, NVME, and FC targets available on the storage array will exceed this size limit. Some targets must be removed to reduce the size of the publish context, and the volume must be unpublished/republished. |
 </div>


### PR DESCRIPTION
This reverts commit 920f2a0cf6d8d48b8892b95e45c38b823c306af7.

# Description
The potential issue that this warning message addressed has been resolved at the driver level. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/2012 |

# Checklist:

- [X] Have you run a grammar and spell checks against your submission?
- [X] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

<img width="1688" height="908" alt="image" src="https://github.com/user-attachments/assets/a5d5051a-2f03-49e3-9c0e-656f583b18f7" />
