### PR TITLE
Simplify Auth v2 deployment by removing karavi-authorization-config Secret requirement

### DIFF
--- a/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
@@ -154,4 +154,4 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       skipCertificateValidation: true
     ```
 
-1. Install the CSI PowerFlex driver following the appropriate documentation for your installation method.
+5. Install the CSI PowerFlex driver following the appropriate documentation for your installation method.

--- a/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
@@ -43,7 +43,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     - Update `skipCertificateValidation` to `true`.
 
-    - The `username` and `password` can be any value since they will be ignored.
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     Example:
 
@@ -65,7 +65,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     - Update `skipCertificateValidation` to `true`.
 
-    - The `username` and `password` can be any value since they will be ignored.
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     Example:
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerflex/_index.md
@@ -19,29 +19,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
    This takes the assumption that Powerflex will be installed in the `vxflexos` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in the [CSI PowerFlex](https://github.com/dell/csi-powerflex/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-{{< collapse id="1" title="Parameters">}}
-   | Parameter                 | Description                                                                                                      | Required | Default                        |
-   | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
-   | username                  | Username for connecting to the backend storage array. This parameter is ignored.                                 | No       | -                              |
-   | password                  | Password for connecting to to the backend storage array. This parameter is ignored.                              | No       | -                              |
-   | intendedEndpoint          | HTTPS REST API endpoint of the backend storage array.                                                            | Yes      | -                              |
-   | endpoint                  | HTTPS localhost endpoint that the authorization sidecar will listen on.                                          | Yes      | https://localhost:9400         |
-   | systemID                  | System ID of the backend storage array.                                                                          | Yes      | " "                            |
-   | skipCertificateValidation | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No       | true                           |
-   | isDefault                 | A boolean that indicates if the array is the default array. This parameter is not used.                          | No       | default value from values.yaml |
-{{< /collapse >}}
-<ul style="list-style-type: none;">
-<li>Create the karavi-authorization-config secret using this command:
-
-  ```bash
-    kubectl -n vxflexos create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-  ```
-</li>
-</ul>
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -55,13 +33,13 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       kubectl -n vxflexos create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
 
     **Operator**
 
     Refer to the [Create Secret](../../../../../getting-started/installation/kubernetes/powerflex/csmoperator/#create-secret) section to prepare `secret.yaml` to configure the driver to communicate with the Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -83,7 +61,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerflex/helm/#install-driver) section to edit the parameters in `samples/config.yaml` to configure the driver to communicate with Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -101,7 +79,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       mdm: "10.0.0.3,10.0.0.4"
     ```
 
-5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
   Alternatively, you can use the minimal sample files provided in respective CSM versions folder under samples [here](https://github.com/dell/csm-operator/tree/main/samples) and install the module using default value.
 
     **Operator**

--- a/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -20,25 +20,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
    This takes the assumption that PowerMax will be installed in the `powermax` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in the [CSI PowerMax](https://github.com/dell/csi-powermax/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-   | Parameter | Description | Required | Default |
-   | --------- | ----------- | -------- |-------- |
-   | username  | Username for connecting to the backend storage array. This parameter is ignored. | No | - |
-   | password  | Password for connecting to to the backend storage array. This parameter is ignored. | No | - |
-   | intendedEndpoint | HTTPS REST API endpoint of the backend storage array. | Yes | - |
-   | endpoint  | HTTPS localhost endpoint that the authorization sidecar will listen on. | Yes | https://localhost:9400 |
-   | systemID  | System ID of the backend storage array. | Yes | " " |
-   | skipCertificateValidation  | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No | true |
-   | isDefault | A boolean that indicates if the array is the default array. This parameter is not used. | No | default value from values.yaml |
-
-    Create the karavi-authorization-config secret using this command:
-
-    ```bash
-    kubectl -n powermax create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-    ```
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -52,13 +34,14 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
       kubectl -n powermax create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with Authorization sidecar.
 
     **Operator**
 
     Refer to the [Install Driver](../../../../../getting-started/installation/kubernetes/powermax/csmoperator/#install-driver) section to prepare `powermax-creds.yaml` to configure the driver to communicate with Authorization sidecar.
 
-    Update endpoint to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`. Leave `username` and `password` with the default values base64 encoded.
+    - Update `primaryEndpoint` and `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
+    - The `username` and `password` can be any value since they will be ignored.
 
     **Note:** Authorization does not currently support the `backupEndpoint` parameter.
 
@@ -83,7 +66,8 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powermax/helm/#install-driver) section where you edit `samples/secret/secret.yaml` with the credentials of the PowerMax.
 
-    Update endpoint to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`. Leave `username` and `password` with the default values base64 encoded.
+    - Update `primaryEndpoint` and `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
+    - The `username` and `password` can be any value since they will be ignored.
 
     **Note:** Authorization does not currently support the `backupEndpoint` parameter.
 
@@ -104,7 +88,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
           maxOutstandingWrite: 10
     ```
 
-5. **Operator Only**: Prepare the reverse proxy configMap using sample [here](https://github.com/dell/csm-operator/blob/main/samples/csireverseproxy/config.yaml). Fill in the appropriate values for driver configuration.
+4. **Operator Only**: Prepare the reverse proxy configMap using sample [here](https://github.com/dell/csm-operator/blob/main/samples/csireverseproxy/config.yaml). Fill in the appropriate values for driver configuration.
    Example: config.yaml
    ```yaml
     port: 2222
@@ -122,7 +106,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         skipCertificateValidation: true
    ```
 
-6. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
   Alternatively, you can use the minimal sample files provided in respective CSM versions folder under samples [here](https://github.com/dell/csm-operator/tree/main/samples) and install the module using default value.
 
     **Operator**
@@ -241,4 +225,4 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
       skipCertificateValidation: true
     ```
 
-7. Install the Dell CSI PowerMax driver following the appropriate documentation for your installation method.
+6. Install the Dell CSI PowerMax driver following the appropriate documentation for your installation method.

--- a/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -41,7 +41,8 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
     Refer to the [Install Driver](../../../../../getting-started/installation/kubernetes/powermax/csmoperator/#install-driver) section to prepare `powermax-creds.yaml` to configure the driver to communicate with Authorization sidecar.
 
     - Update `primaryEndpoint` and `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
-    - The `username` and `password` can be any value since they will be ignored.
+
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     **Note:** Authorization does not currently support the `backupEndpoint` parameter.
 
@@ -67,7 +68,8 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powermax/helm/#install-driver) section where you edit `samples/secret/secret.yaml` with the credentials of the PowerMax.
 
     - Update `primaryEndpoint` and `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
-    - The `username` and `password` can be any value since they will be ignored.
+
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     **Note:** Authorization does not currently support the `backupEndpoint` parameter.
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -181,9 +181,9 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powermax/helm/#install-driver) section to edit the parameters in `my-powermax-settings.yaml` file to configure the driver to communicate with Authorization sidecar.
 
-    - Update `global.storageArrays.endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `global.storageArrays.endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
-    - Update `global.managementServers.endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `global.managementServers.endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `authorization.enabled` to `true`.
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
@@ -48,7 +48,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     - Update `skipCertificateValidation` to `true`.
 
-    - The `username` and `password` can be any value since they will be ignored.
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     Example:
 
@@ -76,7 +76,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     - Update `skipCertificateValidation` to `true`.
 
-    - The `username` and `password` can be any value since they will be ignored.
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     Example:
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
@@ -42,6 +42,8 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
+    - Update `endpointPort` to the port that the authorization sidecar will listen on.
+
     - Update `mountEndpoint` to the PowerScale OneFS API server. For example, 10.0.0.1.
 
     - Update `skipCertificateValidation` to `true`.
@@ -67,6 +69,8 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerscale/helm/#install-driver) section to edit the parameters to prepare the `samples/secret/secret.yaml` file to configure the driver to communicate with Authorization sidecar.
 
     - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
+
+    - Update `endpointPort` to the port that the authorization sidecar will listen on.
 
     - Update `mountEndpoint` to the PowerScale OneFS API server. For example, 10.0.0.1.
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerscale/_index.md
@@ -20,25 +20,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
    This takes the assumption that PowerScale will be installed in the `isilon` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in [CSI PowerScale](https://github.com/dell/csi-powerscale/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-  | Parameter                 | Description                                                                                                      | Required | Default                        |
-  | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
-  | username                  | Username for connecting to the backend storage array. This parameter is ignored.                                 | No       | -                              |
-  | password                  | Password for connecting to to the backend storage array. This parameter is ignored.                              | No       | -                              |
-  | intendedEndpoint          | HTTPS REST API endpoint of the backend storage array.                                                            | Yes      | -                              |
-  | endpoint                  | HTTPS localhost endpoint that the authorization sidecar will listen on.                                          | Yes      | https://localhost:9400         |
-  | systemID                  | Cluster name of the backend storage array.                                                                       | Yes      | " "                            |
-  | skipCertificateValidation | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No       | true                           |
-  | isDefault                 | A boolean that indicates if the array is the default array. This parameter is not used.                          | No       | default value from values.yaml |
-
-  Create the karavi-authorization-config secret using this command:
-
-  ```bash
-  kubectl -n isilon create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-  ```
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -52,13 +34,13 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
       kubectl -n isilon create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with Authorization sidecar.
 
     **Operator**
 
     Refer to the [Prerequisite](../../../../../getting-started/installation/kubernetes/powerscale/csmoperator/#install-driver) section to prepare the `secret.yaml` file to configure the driver to communicate with the CSM Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `mountEndpoint` to the PowerScale OneFS API server. For example, 10.0.0.1.
 
@@ -84,7 +66,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerscale/helm/#install-driver) section to edit the parameters to prepare the `samples/secret/secret.yaml` file to configure the driver to communicate with Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `mountEndpoint` to the PowerScale OneFS API server. For example, 10.0.0.1.
 
@@ -106,7 +88,7 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         skipCertificateValidation: true
     ```
 
-5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
 
     **Operator**
 
@@ -178,4 +160,4 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
       skipCertificateValidation: true
     ```
 
-6. Install the Dell CSI PowerScale driver following the appropriate documentation for your installation method.
+5. Install the Dell CSI PowerScale driver following the appropriate documentation for your installation method.

--- a/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
@@ -48,12 +48,14 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
     Example:
 
     ```yaml
-    - username: "ignored"
-      password: "ignored"
-      systemID: "ID2"
-      endpoint: "https://localhost:9400"
-      skipCertificateValidation: true
-      isDefault: true
+    arrays:
+      - username: "ignored"
+        password: "ignored"
+        globalID: "unique"
+        endpoint: "https://localhost:9400"
+        skipCertificateValidation: true
+        blockProtocol: "FC"
+        isDefault: true
     ```
 
     **Helm**
@@ -69,12 +71,14 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
     Example:
 
     ```yaml
-    - username: "ignored"
-      password: "ignored"
-      systemID: "ID2"
-      endpoint: "https://localhost:9400"
-      skipCertificateValidation: true
-      isDefault: true
+    arrays:
+      - username: "ignored"
+        password: "ignored"
+        globalID: "unique"
+        endpoint: "https://localhost:9400"
+        skipCertificateValidation: true
+        blockProtocol: "FC"
+        isDefault: true
     ```
 
 4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
@@ -152,4 +156,4 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       skipCertificateValidation: true
     ```
 
-6. Install the CSI PowerStore driver following the appropriate documentation for your installation method.
+5. Install the CSI PowerStore driver following the appropriate documentation for your installation method.

--- a/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
@@ -19,7 +19,6 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
    This takes the assumption that PowerStore will be installed in the `powerstore` namespace.
 
-
 2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:

--- a/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
@@ -19,29 +19,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
    This takes the assumption that PowerStore will be installed in the `powerstore` namespace.
 
-2. Edit these parameters in `samples/secret/karavi-authorization-config.json` file in the [CSI PowerStore](https://github.com/dell/csi-powerstore/tree/main/samples/secret/karavi-authorization-config.json) driver and update/add connection information for one or more backend storage arrays. In an instance where multiple CSI drivers are configured on the same Kubernetes cluster, the port range in the *endpoint* parameter must be different for each driver.
-
-{{< collapse id="1" title="Parameters">}}
-   | Parameter                 | Description                                                                                                      | Required | Default                        |
-   | ------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------ |
-   | username                  | Username for connecting to the backend storage array. This parameter is ignored.                                 | No       | -                              |
-   | password                  | Password for connecting to to the backend storage array. This parameter is ignored.                              | No       | -                              |
-   | intendedEndpoint          | HTTPS REST API endpoint of the backend storage array.                                                            | Yes      | -                              |
-   | endpoint                  | HTTPS localhost endpoint that the authorization sidecar will listen on.                                          | Yes      | https://localhost:9400         |
-   | systemID                  | System ID of the backend storage array.                                                                          | Yes      | " "                            |
-   | skipCertificateValidation | A boolean that enables/disables certificate validation of the backend storage array. This parameter is not used. | No       | true                           |
-   | isDefault                 | A boolean that indicates if the array is the default array. This parameter is not used.                          | No       | default value from values.yaml |
-{{< /collapse >}}
-<ul style="list-style-type: none;">
-<li>Create the karavi-authorization-config secret using this command:
-
-  ```bash
-    kubectl -n powerstore create secret generic karavi-authorization-config --from-file=config=samples/secret/karavi-authorization-config.json -o yaml --dry-run=client | kubectl apply -f -
-  ```
-</li>
-</ul>
-
-3. Create the proxy-server-root-certificate secret.
+2. Create the proxy-server-root-certificate secret.
 
     If running in *insecure* mode, create the secret with empty data:
 
@@ -55,13 +33,13 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       kubectl -n powerstore create secret generic proxy-server-root-certificate --from-file=rootCertificate.pem=/path/to/rootCA -o yaml --dry-run=client | kubectl apply -f -
       ```
 
-4. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
+3. Prepare the driver configuration secret, applicable to your driver installation method, to communicate with the Container Storage Modules Authorization sidecar.
 
     **Operator**
 
     Refer to the [Create Secret](../../../../../getting-started/installation/kubernetes/powerstore/csmoperator/#create-secret) section to prepare `secret.yaml` to configure the driver to communicate with the Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -80,7 +58,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     Refer to the [Install the Driver](../../../../../getting-started/installation/kubernetes/powerstore/helm/#install-driver) section to edit the parameters in `samples/config.yaml` to configure the driver to communicate with Authorization sidecar.
 
-    - Update `endpoint` to match the localhost endpoint in `samples/secret/karavi-authorization-config.json`.
+    - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
 
@@ -95,7 +73,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
       isDefault: true
     ```
 
-5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
+4. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.
   Alternatively, you can use the minimal sample files provided in respective CSM versions folder under samples [here](https://github.com/dell/csm-operator/tree/main/samples) and install the module using default value.
 
     **Operator**
@@ -142,7 +120,7 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     - Update `authorization.enabled` to `true`.
 
-    - Update `images.authorization` to the image of Authorization sidecar. 
+    - Update `images.authorization` to the image of Authorization sidecar.
 
     - Update `authorization.proxyHost` to the hostname of Authorization Proxy Server. `csm-authorization.com` is a placeholder for the proxyHost. See the administrator of Authorization for the correct value.
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powerstore/_index.md
@@ -43,6 +43,8 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
 
     - Update `skipCertificateValidation` to `true`.
 
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
+
     Example:
 
     ```yaml
@@ -61,6 +63,8 @@ Given a setup where Kubernetes, a storage system, and the Authorization Proxy Se
     - Update `endpoint` to an HTTPS localhost endpoint that the authorization sidecar will listen on.
 
     - Update `skipCertificateValidation` to `true`.
+
+    - The `username` and `password` fields are not used during authentication and can be set to any value.
 
     Example:
 

--- a/content/docs/getting-started/upgrade/helm/module/authorization.md
+++ b/content/docs/getting-started/upgrade/helm/module/authorization.md
@@ -13,7 +13,13 @@ This section outlines the upgrade steps for Container Storage Modules (CSM) for 
 - Helm Chart Upgrade
 - Upgrading the Dell CSI drivers with CSM for Authorization enabled
 
-## Upgrade Notice: CSM v1.14 → CSM v1.15 (Authorization v2.2.0 → v2.3.0)
+## Upgrade Notices:
+
+**CSM 1.16**
+
+Starting with CSM 1.16, the `karavi-authorization-config` secret is no longer required. However, existing installations that include this secret will continue to function as expected.
+
+**CSM v1.14 → CSM v1.15 (Authorization v2.2.0 → v2.3.0)**
 
 Starting with CSM 1.15, CSM Authorization (v2.3.0) requires users to configure storage credentials prior to deployment. This is a mandatory step to ensure proper access to external storage systems.
 

--- a/content/docs/getting-started/upgrade/helm/module/authorization.md
+++ b/content/docs/getting-started/upgrade/helm/module/authorization.md
@@ -15,13 +15,13 @@ This section outlines the upgrade steps for Container Storage Modules (CSM) for 
 
 ## Upgrade Notices:
 
-**CSM 1.16**
+**CSM v1.16**
 
-Starting with CSM 1.16, the `karavi-authorization-config` secret is no longer required. However, existing installations that include this secret will continue to function as expected.
+Starting with CSM v1.16 and CSM Authorization v2.4.0, the `karavi-authorization-config` secret is no longer required. However, existing installations that include this secret will continue to function as expected.
 
 **CSM v1.14 → CSM v1.15 (Authorization v2.2.0 → v2.3.0)**
 
-Starting with CSM 1.15, CSM Authorization (v2.3.0) requires users to configure storage credentials prior to deployment. This is a mandatory step to ensure proper access to external storage systems.
+Starting with CSM v1.15 and CSM Authorization v2.3.0, users must configure storage credentials prior to deployment. This is a mandatory step to ensure proper access to external storage systems.
 
 You can configure storage credentials using one of the following methods:
 

--- a/content/docs/getting-started/upgrade/operator/authorization_upgrade.md
+++ b/content/docs/getting-started/upgrade/operator/authorization_upgrade.md
@@ -16,13 +16,13 @@ This section outlines the upgrade steps for Container Storage Modules (CSM) for 
 
 ## Upgrade Notices:
 
-**CSM 1.16**
+**CSM v1.16**
 
-Starting with CSM 1.16, the `karavi-authorization-config` secret is no longer required. However, existing installations that include this secret will continue to function as expected.
+Starting with CSM v1.16 and CSM Authorization v2.4.0, the `karavi-authorization-config` secret is no longer required. However, existing installations that include this secret will continue to function as expected.
 
 **CSM v1.14 → CSM v1.15 (Authorization v2.2.0 → v2.3.0)**
 
-Starting with CSM 1.15, CSM Authorization (v2.3.0) requires users to configure storage credentials prior to deployment. This is a mandatory step to ensure proper access to external storage systems.
+Starting with CSM v1.15 and CSM Authorization v2.3.0, users must configure storage credentials prior to deployment. This is a mandatory step to ensure proper access to external storage systems.
 
 You can configure storage credentials using one of the following methods:
 

--- a/content/docs/getting-started/upgrade/operator/authorization_upgrade.md
+++ b/content/docs/getting-started/upgrade/operator/authorization_upgrade.md
@@ -14,7 +14,13 @@ This section outlines the upgrade steps for Container Storage Modules (CSM) for 
 1) Upgrading the Authorization proxy server
 2) Upgrading CSI Driver, Authorization sidecar with Authorization module enabled
 
-## Upgrade Notice: CSM v1.14 → CSM v1.15 (Authorization v2.2.0 → v2.3.0)
+## Upgrade Notices:
+
+**CSM 1.16**
+
+Starting with CSM 1.16, the `karavi-authorization-config` secret is no longer required. However, existing installations that include this secret will continue to function as expected.
+
+**CSM v1.14 → CSM v1.15 (Authorization v2.2.0 → v2.3.0)**
 
 Starting with CSM 1.15, CSM Authorization (v2.3.0) requires users to configure storage credentials prior to deployment. This is a mandatory step to ensure proper access to external storage systems.
 


### PR DESCRIPTION
# Description
Doc changes for removing the dependency on the karavi-authorization-config secret for deploying Auth v2 with PowerStore, PowerFlex, PowerScale, and PowerMax. 
New deployments only require the driver secret, simplifying the configuration process. Existing deployments using the karavi-authorization-config secret will continue to function as expected, ensuring seamless upgrades.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1583 |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [ ] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?