### PR TITLE
Fix PowerMax active read/write configuration

### DIFF
--- a/content/docs/concepts/authorization/v2.x/configuration/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/_index.md
@@ -61,6 +61,7 @@ A `storage` entity in Container Storage Modules Authorization consists of the st
 
 >__Note__:
 > - You must specify exactly one option for the storageSystemCredentials field, e.g. secretProviderClass.
+> - For PowerStore, the endpoint must be appeneded with `/api/rest`. For example, `https://10.0.0.1/api/rest`.
 
 Edit these parameters in the manifest:
 

--- a/content/docs/concepts/authorization/v2.x/configuration/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/_index.md
@@ -61,7 +61,7 @@ A `storage` entity in Container Storage Modules Authorization consists of the st
 
 >__Note__:
 > - You must specify exactly one option for the storageSystemCredentials field, e.g. secretProviderClass.
-> - For PowerStore, the endpoint must be appeneded with `/api/rest`. For example, `https://10.0.0.1/api/rest`.
+> - For PowerStore, the endpoint must be appended with `/api/rest`. For example, `https://10.0.0.1/api/rest`.
 
 Edit these parameters in the manifest:
 

--- a/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -68,10 +68,10 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
     **Helm**
@@ -95,10 +95,10 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
 4. **Operator Only**: Prepare the reverse proxy configMap using sample [here](https://github.com/dell/csm-operator/blob/main/samples/csireverseproxy/config.yaml). Fill in the appropriate values for driver configuration.

--- a/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -8,7 +8,6 @@ description: >
 {{< message text="1" >}}
 {{% /pageinfo %}}
 
-
 ## Configuring PowerMax CSI Driver with Container Storage Modules for Authorization
 
 Given a setup where Kubernetes, a storage system, and the Container Storage Modules for Authorization Proxy Server are deployed, follow these steps to configure the CSI Drivers to work with the Authorization sidecar:

--- a/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/docs/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -8,6 +8,7 @@ description: >
 {{< message text="1" >}}
 {{% /pageinfo %}}
 
+
 ## Configuring PowerMax CSI Driver with Container Storage Modules for Authorization
 
 Given a setup where Kubernetes, a storage system, and the Container Storage Modules for Authorization Proxy Server are deployed, follow these steps to configure the CSI Drivers to work with the Authorization sidecar:

--- a/content/docs/getting-started/installation/kubernetes/powerflex/csmoperator/csm-modules/authorizationv2-0.md
+++ b/content/docs/getting-started/installation/kubernetes/powerflex/csmoperator/csm-modules/authorizationv2-0.md
@@ -6,4 +6,4 @@ description: >
  Container Storage Modules (CSM) for Authorization v2.0 Operator deployment
 ---
 
-{{<include file="content/docs/getting-started/installation/operator/modules/authorizationv2-0.md" hideIds="2,3">}}
+{{<include file="content/docs/getting-started/installation/operator/modules/authorizationv2-0.md">}}

--- a/content/docs/getting-started/installation/kubernetes/powermax/csmoperator/csm-modules/authorizationv2-0.md
+++ b/content/docs/getting-started/installation/kubernetes/powermax/csmoperator/csm-modules/authorizationv2-0.md
@@ -6,4 +6,4 @@ description: >
   Container Storage Modules (CSM) for Authorization v2.0 Operator deployment
 ---
 
-{{<include file="content/docs/getting-started/installation/operator/modules/authorizationv2-0.md" hideIds="1,3" >}}
+{{<include file="content/docs/getting-started/installation/operator/modules/authorizationv2-0.md">}}

--- a/content/docs/getting-started/installation/kubernetes/powermax/helm/_index.md
+++ b/content/docs/getting-started/installation/kubernetes/powermax/helm/_index.md
@@ -60,10 +60,10 @@ Install Helm 3 on the master node before you install CSI Driver for PowerMax.
         password: password
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
       - endpoint: https://backup-1.unisphe.re:8443
         username: admin2
         password: password2

--- a/content/docs/getting-started/installation/openshift/powermax/csmoperator/_index.md
+++ b/content/docs/getting-started/installation/openshift/powermax/csmoperator/_index.md
@@ -141,7 +141,7 @@ dell-csm-operator-controller-manager-86dcdc8c48-6dkxm      2/2     Running      
 
 4. **Create the Reverse Proxy TLS Secret**
 
-    Referencing the TLS certificate and key created in the [CSI PowerMax Reverse Proxy](./#csi-powermax-reverse-proxy) prerequisite, create the `csirevproxy-tls-secret` secret.
+    Referencing the TLS certificate and key created in the [CSI PowerMax Reverse Proxy](../prerequisite/#csi-powermax-reverse-proxy) prerequisite, create the `csirevproxy-tls-secret` secret.
     ```bash
     oc create secret -n powermax tls csirevproxy-tls-secret --cert=tls.crt --key=tls.key
     ```

--- a/content/v1/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/v1/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -104,10 +104,10 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
     **Helm**
@@ -129,10 +129,10 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
 5. **Operator Only**: Prepare the reverse proxy configMap using sample [here](https://github.com/dell/csm-operator/blob/main/samples/csireverseproxy/config.yaml). Fill in the appropriate values for driver configuration.

--- a/content/v1/getting-started/installation/kubernetes/powermax/helm/_index.md
+++ b/content/v1/getting-started/installation/kubernetes/powermax/helm/_index.md
@@ -60,10 +60,10 @@ Install Helm 3 on the master node before you install CSI Driver for PowerMax.
         password: password
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
       - endpoint: https://backup-1.unisphe.re:8443
         username: admin2
         password: password2

--- a/content/v2/concepts/authorization/v1.x/configuration/powermax/_index.md
+++ b/content/v2/concepts/authorization/v1.x/configuration/powermax/_index.md
@@ -68,10 +68,10 @@ Create the karavi-authorization-config secret using this command:
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
     **Operator**
@@ -93,10 +93,10 @@ Create the karavi-authorization-config secret using this command:
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
 5. Enable Container Storage Modules Authorization in the driver installation applicable to your installation method.

--- a/content/v2/concepts/authorization/v2.x/configuration/powermax/_index.md
+++ b/content/v2/concepts/authorization/v2.x/configuration/powermax/_index.md
@@ -73,10 +73,10 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
     **Helm**
@@ -98,10 +98,10 @@ Given a setup where Kubernetes, a storage system, and the Container Storage Modu
         password: -
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
     ```
 
 5. **Operator Only**: Prepare the reverse proxy configMap using sample [here](https://github.com/dell/csm-operator/tree/release/{{< version-v2 key="csm-operator_latest_version" >}}/samples/csireverseproxy/config.yaml). Fill in the appropriate values for driver configuration.

--- a/content/v2/getting-started/installation/kubernetes/powermax/helm/_index.md
+++ b/content/v2/getting-started/installation/kubernetes/powermax/helm/_index.md
@@ -60,10 +60,10 @@ Install Helm 3 on the master node before you install CSI Driver for PowerMax.
         password: password
         skipCertificateValidation: true
         limits:
-          maxActiveRead: 10
-          maxActiveWrite: 10
-          maxOutstandingRead: 10
-          maxOutstandingWrite: 10
+          maxActiveRead: 5
+          maxActiveWrite: 4
+          maxOutstandingRead: 50
+          maxOutstandingWrite: 50
       - endpoint: https://backup-1.unisphe.re:8443
         username: admin2
         password: password2


### PR DESCRIPTION
# Description

- Revert PowerMax active read/write configuration to default values, as they were in previous versions
- Add a note in Authorization configuration that the storage resource for PowerStore endpoint needs `/api/rest`
- Add all driver links in Authorization configure pages

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
- [ ] Have you tested whether the hyperlinks are working properly?
- [ ] Did you add the examples wherever applicable?
- [ ] Have you added high-resolution images?

