### PR TITLE
Announcement on the CSM documentation

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -2,4 +2,6 @@
 title: "Container Storage Modules"
 linkTitle: "Container Storage Modules"
 weight: 20
---- 
+---
+
+{{< message text="25" >}}

--- a/content/docs/release/_index.md
+++ b/content/docs/release/_index.md
@@ -10,7 +10,7 @@ Description: >
 ## Notifications
 
  **General:**
-
+> * <span><span/>{{< message text="25" >}}
 > * <span><span/>{{< message text="8" >}}
 > * <span><span/>{{< message text="7" >}}
 > * <span><span/>{{< message text="1" >}}

--- a/layouts/shortcodes/message.html
+++ b/layouts/shortcodes/message.html
@@ -44,6 +44,8 @@ Starting from CSM version 1.16, users can utilize the <code>spec.version</code> 
 Starting with CSM v1.16 and CSM Authorization v2.4.0, users can utilize the <code>spec.version</code> parameter for automatic image management.</br> For more details click on <a href='{{ relref . "docs/getting-started/installation/operator/image-configuration.md" }}'>Advanced Image Configuration Options</a> section. </br> </br> </br> <b>If neither method is configured, the operator automatically falls back to using the default image set associated with the Authorization Proxy Server. This fallback only works for CSM 1.16 (Authorization v2.4.0).</b>
 {{ else if eq (.Get "text") "24" }}
 As of Container Storage Modules (CSM) v1.16, the Installation Wizard will be deprecated. To ensure a streamlined and fully supported deployment experience, User should transition to the automated installation workflow using <a href="/csm-docs/docs/tooling/cli/#dellctl-install">dellctl</a>
+{{ else if eq (.Get "text") "25" }}
+<span style="color: #036cc2;"><b>We are moving! Our Dell CSM documentation will be moving to Dell.com at the end of May 2026. Stay tuned for our new location. </b></span>
 {{else}}
 <p>Default text if no valid parameter is passed.</p>
 {{ end }}


### PR DESCRIPTION
# Description
Add "We are moving!" announcement across the CSM documentation to inform users that Dell CSM documentation will be moving to Dell.com at the end of May 2026. The announcement is displayed in blue color with bold formatting and includes a Notifications button on the home page.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run a grammar and spell checks against your submission?
- [x] Have you tested the changes locally?
<img width="1317" height="239" alt="image" src="https://github.com/user-attachments/assets/da13f764-fc7d-46e9-a155-4f60e93681a5" />
<img width="1417" height="237" alt="image" src="https://github.com/user-attachments/assets/6f24f4e0-9380-4e97-a92c-6f3c7e6c16af" />

